### PR TITLE
Fix doc: proper main class in the start instance command

### DIFF
--- a/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java
@@ -74,7 +74,7 @@ import java.util.Properties;
  * <pre>
  * {@code
  * $ java -cp target/kafka-streams-examples-3.3.0-standalone.jar \
- *      io.confluent.examples.streams.interactivequeries.InteractiveQueriesExample 7070
+ *      io.confluent.examples.streams.interactivequeries.WordCountInteractiveQueriesExample 7070
  * }
  * </pre>
  *
@@ -85,7 +85,7 @@ import java.util.Properties;
  * <pre>
  * {@code
  * $ java -cp target/kafka-streams-examples-3.3.0-standalone.jar \
- *      io.confluent.examples.streams.interactivequeries.InteractiveQueriesExample 7071
+ *      io.confluent.examples.streams.interactivequeries.WordCountInteractiveQueriesExample 7071
  * }
  * </pre>
  *


### PR DESCRIPTION
This PR fixes the following issue: the starting application command within the documentation of the WordCountInteractive queries example was not pointing to the proper main class.

A previous PR was created in the [confluentinc-examples](https://github.com/confluentinc/examples/pull/149) repo and as per @mjsax comment I created this one as well.