### PR TITLE
add print.key property for example

### DIFF
--- a/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
+++ b/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
@@ -78,7 +78,7 @@ import org.apache.kafka.streams.kstream.{KStream, KStreamBuilder}
   *
   * {{{
   * $ bin/kafka-console-consumer --new-consumer --bootstrap-server localhost:9092 --topic UppercasedTextLinesTopic --from-beginning
-  * $ bin/kafka-console-consumer --new-consumer --bootstrap-server localhost:9092 --topic OriginalAndUppercasedTopic --from-beginning
+  * $ bin/kafka-console-consumer --new-consumer --bootstrap-server localhost:9092 --topic OriginalAndUppercasedTopic --from-beginning  --property print.key=true
   * }}}
   *
   * You should see output data similar to:


### PR DESCRIPTION
Needed to add `--property print.key=true` for example 