### PR TITLE
The incorrect jersey-container-servlet-core dependency forces servlet 2.x implementation that makes async request fail. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet-core</artifactId>
+            <artifactId>jersey-container-servlet</artifactId>
             <version>${jersey.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/io/confluent/examples/streams/microservices/OrderDetailsService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/OrderDetailsService.java
@@ -163,7 +163,7 @@ public class OrderDetailsService implements Service {
 
   public static void main(String[] args) throws Exception {
     OrderDetailsService service = new OrderDetailsService();
-    service.startService(MicroserviceUtils.parseArgsAndConfigure(args));
+    service.start(MicroserviceUtils.parseArgsAndConfigure(args));
     addShutdownHookAndBlock(service);
   }
 }


### PR DESCRIPTION
The current version of OrderService blows on POST request with 
javax.servlet.ServletException: java.lang.UnsupportedOperationException: Asynchronous processing not supported on Servlet 2.x container.
jersey-container-servlet needs to be a dependency since it is servlet 3.x implementation, not jersey-container-servlet-core which is servlet 2.x implementation. See https://mvnrepository.com/artifact/org.glassfish.jersey.containers/jersey-container-servlet-core and https://mvnrepository.com/artifact/org.glassfish.jersey.containers/jersey-container-servlet