### PR TITLE
MINOR: Fix incorrect OrderServiceTest

### DIFF
--- a/src/test/java/io/confluent/examples/streams/ValidateStateWithInteractiveQueriesLambdaIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/ValidateStateWithInteractiveQueriesLambdaIntegrationTest.java
@@ -95,7 +95,6 @@ public class ValidateStateWithInteractiveQueriesLambdaIntegrationTest {
     // The commit interval for flushing records to state stores and downstream must be lower than
     // this integration test's timeout (30 secs) to ensure we observe the expected processing results.
     streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 2 * 1000);
-    streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     // Use a temporary directory for storing state, which will be automatically removed after the test.
     streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
 

--- a/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
+++ b/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
@@ -19,12 +19,20 @@ import io.confluent.examples.streams.zookeeper.ZooKeeperEmbedded;
 import io.confluent.kafka.schemaregistry.RestApp;
 import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
 import kafka.server.KafkaConfig$;
+import kafka.utils.ZkUtils;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.security.JaasUtils;
+import org.apache.kafka.test.TestCondition;
+import org.apache.kafka.test.TestUtils;
 import org.junit.rules.ExternalResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * Runs an in-memory, "embedded" Kafka cluster with 1 ZooKeeper instance, 1 Kafka broker, and 1
@@ -38,6 +46,7 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
   private static final String AVRO_COMPATIBILITY_TYPE = AvroCompatibilityLevel.NONE.name;
 
   private ZooKeeperEmbedded zookeeper;
+  private ZkUtils zkUtils = null;
   private KafkaEmbedded broker;
   private RestApp schemaRegistry;
   private final Properties brokerConfig;
@@ -68,6 +77,12 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     log.debug("Starting a ZooKeeper instance...");
     zookeeper = new ZooKeeperEmbedded();
     log.debug("ZooKeeper instance is running at {}", zookeeper.connectString());
+
+    zkUtils = ZkUtils.apply(
+        zookeeper.connectString(),
+        30000,
+        30000,
+        JaasUtils.isZkSecurityEnabled());
 
     Properties effectiveBrokerConfig = effectiveBrokerConfigFrom(brokerConfig, zookeeper);
     log.debug("Starting a Kafka instance on port {} ...",
@@ -197,7 +212,40 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     broker.createTopic(topic, partitions, replication, topicConfig);
   }
 
+  /**
+   * Deletes multiple topics and blocks until all topics got deleted.
+   *
+   * @param timeoutMs the max time to wait for the topics to be deleted (does not block if {@code <= 0})
+   * @param topics the name of the topics
+   */
+  public void deleteTopicsAndWait(final long timeoutMs, final String... topics) throws InterruptedException {
+    for (final String topic : topics) {
+      try {
+        broker.deleteTopic(topic);
+      } catch (final UnknownTopicOrPartitionException e) { }
+    }
+
+    if (timeoutMs > 0) {
+      TestUtils.waitForCondition(new TopicsDeletedCondition(topics), timeoutMs, "Topics not deleted after " + timeoutMs + " milli seconds.");
+    }
+  }
+
   public boolean isRunning() {
     return running;
   }
+
+  private final class TopicsDeletedCondition implements TestCondition {
+    final Set<String> deletedTopics = new HashSet<>();
+
+    private TopicsDeletedCondition(final String... topics) {
+      Collections.addAll(deletedTopics, topics);
+    }
+
+    @Override
+    public boolean conditionMet() {
+      final Set<String> allTopics = new HashSet<>(scala.collection.JavaConversions.seqAsJavaList(zkUtils.getAllTopics()));
+      return !allTopics.removeAll(deletedTopics);
+    }
+  }
+
 }

--- a/src/test/java/io/confluent/examples/streams/kafka/KafkaEmbedded.java
+++ b/src/test/java/io/confluent/examples/streams/kafka/KafkaEmbedded.java
@@ -175,4 +175,21 @@ public class KafkaEmbedded {
     zkClient.close();
   }
 
+  /**
+   * Delete a Kafka topic.
+   *
+   * @param topic The name of the topic.
+   */
+  public void deleteTopic(String topic) {
+    log.debug("Deleting topic {}", topic);
+    ZkClient zkClient = new ZkClient(
+        zookeeperConnect(),
+        DEFAULT_ZK_SESSION_TIMEOUT_MS,
+        DEFAULT_ZK_CONNECTION_TIMEOUT_MS,
+        ZKStringSerializer$.MODULE$);
+    boolean isSecure = false;
+    ZkUtils zkUtils = new ZkUtils(zkClient, new ZkConnection(zookeeperConnect()), isSecure);
+    AdminUtils.deleteTopic(zkUtils, topic);
+    zkClient.close();
+  }
 }

--- a/src/test/java/io/confluent/examples/streams/microservices/EmailServiceTest.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/EmailServiceTest.java
@@ -1,11 +1,5 @@
 package io.confluent.examples.streams.microservices;
 
-import static io.confluent.examples.streams.avro.microservices.OrderState.CREATED;
-import static io.confluent.examples.streams.avro.microservices.Product.UNDERPANTS;
-import static io.confluent.examples.streams.microservices.domain.Schemas.Topics;
-import static io.confluent.examples.streams.microservices.domain.beans.OrderId.id;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.confluent.examples.streams.avro.microservices.Customer;
 import io.confluent.examples.streams.avro.microservices.Order;
 import io.confluent.examples.streams.avro.microservices.Payment;
@@ -16,6 +10,14 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.Collections;
+
+import static io.confluent.examples.streams.avro.microservices.OrderState.CREATED;
+import static io.confluent.examples.streams.avro.microservices.Product.UNDERPANTS;
+import static io.confluent.examples.streams.microservices.domain.Schemas.Topics;
+import static io.confluent.examples.streams.microservices.domain.beans.OrderId.id;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class EmailServiceTest extends MicroserviceTestUtils {
 
@@ -35,7 +37,7 @@ public class EmailServiceTest extends MicroserviceTestUtils {
   }
 
   @After
-  public void tearDown() throws Exception {
+  public void tearDown() {
     emailService.stop();
     CLUSTER.stop();
   }
@@ -56,14 +58,14 @@ public class EmailServiceTest extends MicroserviceTestUtils {
       complete = true;
     });
 
-    send(Topics.CUSTOMERS, new KeyValue(customer.getId(), customer));
-    send(Topics.ORDERS, new KeyValue(order.getId(), order));
-    send(Topics.PAYMENTS, new KeyValue(payment.getId(), payment));
+    send(Topics.CUSTOMERS, Collections.singleton(new KeyValue<>(customer.getId(), customer)));
+    send(Topics.ORDERS, Collections.singleton(new KeyValue<>(order.getId(), order)));
+    send(Topics.PAYMENTS, Collections.singleton(new KeyValue<>(payment.getId(), payment)));
 
     //When
     emailService.start(CLUSTER.bootstrapServers());
 
     //Then
-    TestUtils.waitForCondition(() -> complete == true, "Email was never sent.");
+    TestUtils.waitForCondition(() -> complete, "Email was never sent.");
   }
 }

--- a/src/test/java/io/confluent/examples/streams/microservices/OrdersServiceTest.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/OrdersServiceTest.java
@@ -9,6 +9,7 @@ import io.confluent.examples.streams.microservices.domain.beans.OrderBean;
 import io.confluent.examples.streams.microservices.util.MicroserviceTestUtils;
 import io.confluent.examples.streams.microservices.util.Paths;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -19,11 +20,11 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import java.net.HttpURLConnection;
+import java.util.Collections;
 
 import static io.confluent.examples.streams.avro.microservices.Order.newBuilder;
 import static io.confluent.examples.streams.microservices.domain.beans.OrderId.id;
 import static io.confluent.examples.streams.microservices.util.MicroserviceUtils.MIN;
-import static java.util.Arrays.asList;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.Assert.fail;
@@ -35,7 +36,6 @@ public class OrdersServiceTest extends MicroserviceTestUtils {
 
   @BeforeClass
   public static void startKafkaCluster() {
-    CLUSTER.createTopic(Topics.ORDERS.name());
     Schemas.configureSerdesWithSchemaRegistryUrl(CLUSTER.schemaRegistryUrl());
   }
 
@@ -43,10 +43,19 @@ public class OrdersServiceTest extends MicroserviceTestUtils {
   public void shutdown() {
     if (rest != null) {
       rest.stop();
+      rest.cleanLocalState();
     }
     if (rest2 != null) {
       rest2.stop();
+      rest2.cleanLocalState();
     }
+  }
+
+  @Before
+  public void prepareKafkaCluster() throws Exception {
+    CLUSTER.deleteTopicsAndWait(30000, Topics.ORDERS.name(), "OrdersService-orders-store-changelog");
+    CLUSTER.createTopic(Topics.ORDERS.name());
+    Schemas.configureSerdesWithSchemaRegistryUrl(CLUSTER.schemaRegistryUrl());
   }
 
   @Test
@@ -91,8 +100,8 @@ public class OrdersServiceTest extends MicroserviceTestUtils {
 
 
   @Test
-  public void shouldGetValidatedOrderOnRequest() throws Exception {
-    Order orderV1 = new Order(id(1L), 2L, OrderState.CREATED, Product.JUMPERS, 10, 100d);
+  public void shouldGetValidatedOrderOnRequest() {
+    Order orderV1 = new Order(id(1L), 3L, OrderState.CREATED, Product.JUMPERS, 10, 100d);
     OrderBean beanV1 = OrderBean.toBean(orderV1);
 
     final Client client = ClientBuilder.newClient();
@@ -108,7 +117,7 @@ public class OrdersServiceTest extends MicroserviceTestUtils {
         .post(Entity.json(beanV1));
 
     //Simulate the order being validated
-    MicroserviceTestUtils.sendOrders(asList(
+    MicroserviceTestUtils.sendOrders(Collections.singletonList(
         newBuilder(orderV1)
             .setState(OrderState.VALIDATED)
             .build()));
@@ -125,7 +134,7 @@ public class OrdersServiceTest extends MicroserviceTestUtils {
   }
 
   @Test
-  public void shouldTimeoutGetIfNoResponseIsFound() throws Exception {
+  public void shouldTimeoutGetIfNoResponseIsFound() {
     final Client client = ClientBuilder.newClient();
 
     //Start the rest interface
@@ -147,8 +156,8 @@ public class OrdersServiceTest extends MicroserviceTestUtils {
   }
 
   @Test
-  public void shouldGetOrderByIdWhenOnDifferentHost() throws Exception {
-    OrderBean order = new OrderBean(id(1L), 2L, OrderState.VALIDATED, Product.JUMPERS, 10, 100d);
+  public void shouldGetOrderByIdWhenOnDifferentHost() {
+    OrderBean order = new OrderBean(id(1L), 4L, OrderState.VALIDATED, Product.JUMPERS, 10, 100d);
     final Client client = ClientBuilder.newClient();
 
     //Given two rest servers on different ports


### PR DESCRIPTION
OrderServiceTest need to cleanup the used order-topic between tests. Otherwise, the test does not start with a clean test environment.

The test sometimes fails with
```
org.junit.ComparisonFailure: expected:<...customerId=2, state=[CRE]ATED, product=JUMPER...> but was:<...customerId=2, state=[VALID]ATED, product=JUMPER...>
	at io.confluent.examples.streams.microservices.OrdersServiceTest.shouldPostOrderAndGetItBack(OrdersServiceTest.java:79)
```

Updating the customer-id in each test case shows, that data from another test run is consumed:
```
org.junit.ComparisonFailure: expected:<...{id='1', customerId=[4], state=VALIDATED, p...> but was:<...{id='1', customerId=[3], state=VALIDATED, p...>
	at io.confluent.examples.streams.microservices.OrdersServiceTest.shouldGetOrderByIdWhenOnDifferentHost(OrdersServiceTest.java:175)
```
This issue was not exposed before, as all test used the same client-id -- I suspect that the test only passed because all tests used the same Order-object and thus, even if reading data from a wrong test test, this issue was not detected as the test saw the data as expected.

Not sure, why the test sometime passed -- must be some race condition between test runs -- maybe test execution order.