### PR TITLE
Compilation failure of all the classes which are dependent on "Avro generated sources" due to "Avro generated sources" missing in the build path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,7 @@
                         <configuration>
                             <sources>
                                 <source>src/main/scala</source>
+								<source>${project.build.directory}/generated-sources</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -294,6 +295,7 @@
                         <configuration>
                             <sources>
                                 <source>src/test/scala</source>
+								<source>${project.build.directory}/generated-sources</source>
                             </sources>
                         </configuration>
                     </execution>


### PR DESCRIPTION
@mjsax branch off 3.3.0-post. Please check. 