### PR TITLE
don't use /tmp/kafka-streams as state.dir in microservices tests

### DIFF
--- a/src/main/java/io/confluent/examples/streams/microservices/FraudService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/FraudService.java
@@ -47,8 +47,8 @@ public class FraudService implements Service {
   private KafkaStreams streams;
 
   @Override
-  public void start(String bootstrapServers) {
-    streams = processStreams(bootstrapServers, "/tmp/kafka-streams");
+  public void start(String bootstrapServers, String stateDir) {
+    streams = processStreams(bootstrapServers, stateDir);
     streams.cleanUp(); //don't do this in prod as it clears your state stores
     streams.start();
     log.info("Started Service " + getClass().getSimpleName());
@@ -111,7 +111,7 @@ public class FraudService implements Service {
 
   public static void main(String[] args) throws Exception {
     FraudService service = new FraudService();
-    service.start(parseArgsAndConfigure(args));
+    service.start(parseArgsAndConfigure(args), "/tmp/kafka-streams");
     addShutdownHookAndBlock(service);
   }
 

--- a/src/main/java/io/confluent/examples/streams/microservices/FraudService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/FraudService.java
@@ -47,7 +47,7 @@ public class FraudService implements Service {
   private KafkaStreams streams;
 
   @Override
-  public void start(String bootstrapServers, String stateDir) {
+  public void start(final String bootstrapServers, final String stateDir) {
     streams = processStreams(bootstrapServers, stateDir);
     streams.cleanUp(); //don't do this in prod as it clears your state stores
     streams.start();

--- a/src/main/java/io/confluent/examples/streams/microservices/InventoryService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/InventoryService.java
@@ -48,7 +48,7 @@ public class InventoryService implements Service {
   private KafkaStreams streams;
 
   @Override
-  public void start(String bootstrapServers, String stateDir) {
+  public void start(final String bootstrapServers, final String stateDir) {
     streams = processStreams(bootstrapServers, stateDir);
     streams.cleanUp(); //don't do this in prod as it clears your state stores
     streams.start();

--- a/src/main/java/io/confluent/examples/streams/microservices/InventoryService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/InventoryService.java
@@ -48,8 +48,8 @@ public class InventoryService implements Service {
   private KafkaStreams streams;
 
   @Override
-  public void start(String bootstrapServers) {
-    streams = processStreams(bootstrapServers, "/tmp/kafka-streams");
+  public void start(String bootstrapServers, String stateDir) {
+    streams = processStreams(bootstrapServers, stateDir);
     streams.cleanUp(); //don't do this in prod as it clears your state stores
     streams.start();
     log.info("Started Service " + getClass().getSimpleName());
@@ -149,7 +149,7 @@ public class InventoryService implements Service {
 
   public static void main(String[] args) throws Exception {
     InventoryService service = new InventoryService();
-    service.start(parseArgsAndConfigure(args));
+    service.start(parseArgsAndConfigure(args), "/tmp/kafka-streams");
     addShutdownHookAndBlock(service);
   }
 }

--- a/src/main/java/io/confluent/examples/streams/microservices/OrderDetailsService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/OrderDetailsService.java
@@ -53,7 +53,7 @@ public class OrderDetailsService implements Service {
   private volatile boolean running;
 
   @Override
-  public void start(String bootstrapServers, String stateDir) {
+  public void start(final String bootstrapServers, final String stateDir) {
     executorService.execute(() -> startService(bootstrapServers));
     running = true;
     log.info("Started Service " + getClass().getSimpleName());

--- a/src/main/java/io/confluent/examples/streams/microservices/OrderDetailsService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/OrderDetailsService.java
@@ -53,7 +53,7 @@ public class OrderDetailsService implements Service {
   private volatile boolean running;
 
   @Override
-  public void start(String bootstrapServers) {
+  public void start(String bootstrapServers, String stateDir) {
     executorService.execute(() -> startService(bootstrapServers));
     running = true;
     log.info("Started Service " + getClass().getSimpleName());
@@ -165,7 +165,7 @@ public class OrderDetailsService implements Service {
 
   public static void main(String[] args) throws Exception {
     OrderDetailsService service = new OrderDetailsService();
-    service.start(MicroserviceUtils.parseArgsAndConfigure(args));
+    service.start(MicroserviceUtils.parseArgsAndConfigure(args), "/tmp/kafka-streams");
     addShutdownHookAndBlock(service);
   }
 }

--- a/src/main/java/io/confluent/examples/streams/microservices/OrdersService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/OrdersService.java
@@ -306,8 +306,9 @@ public class OrdersService implements Service {
         callback(response, bean.getId()));
   }
 
+  @SuppressWarnings("unchecked")
   @Override
-  public void start(String bootstrapServers, String stateDir) {
+  public void start(final String bootstrapServers, final String stateDir) {
     jettyServer = startJetty(port, this);
     port = jettyServer.getURI().getPort(); // update port, in case port was zero
     producer = startProducer(bootstrapServers, ORDER_VALIDATIONS);

--- a/src/main/java/io/confluent/examples/streams/microservices/OrdersService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/OrdersService.java
@@ -307,7 +307,7 @@ public class OrdersService implements Service {
   }
 
   @Override
-  public void start(String bootstrapServers) {
+  public void start(String bootstrapServers, String stateDir) {
     jettyServer = startJetty(port, this);
     port = jettyServer.getURI().getPort(); // update port, in case port was zero
     producer = startProducer(bootstrapServers, ORDER_VALIDATIONS);
@@ -388,7 +388,7 @@ public class OrdersService implements Service {
 
     Schemas.configureSerdesWithSchemaRegistryUrl(schemaRegistryUrl);
     OrdersService service = new OrdersService(restHostname, restPort == null ? 0 : Integer.valueOf(restPort));
-    service.start(bootstrapServers);
+    service.start(bootstrapServers, "/tmp/kafka-streams");
     addShutdownHookAndBlock(service);
   }
 }

--- a/src/main/java/io/confluent/examples/streams/microservices/Service.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/Service.java
@@ -2,7 +2,7 @@ package io.confluent.examples.streams.microservices;
 
 public interface Service {
 
-  void start(String bootstrapServers);
+  void start(String bootstrapServers, String stateDir);
 
   void stop();
 }

--- a/src/main/java/io/confluent/examples/streams/microservices/ValidationsAggregatorService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/ValidationsAggregatorService.java
@@ -56,8 +56,8 @@ public class ValidationsAggregatorService implements Service {
   private KafkaStreams streams;
 
   @Override
-  public void start(String bootstrapServers) {
-    streams = aggregateOrderValidations(bootstrapServers, "/tmp/kafka-streams");
+  public void start(String bootstrapServers, String stateDir) {
+    streams = aggregateOrderValidations(bootstrapServers, stateDir);
     streams.cleanUp(); //don't do this in prod as it clears your state stores
     streams.start();
     log.info("Started Service " + getClass().getSimpleName());
@@ -122,7 +122,7 @@ public class ValidationsAggregatorService implements Service {
 
   public static void main(String[] args) throws Exception {
     ValidationsAggregatorService service = new ValidationsAggregatorService();
-    service.start(parseArgsAndConfigure(args));
+    service.start(parseArgsAndConfigure(args), "/tmp/kafka-streams");
     addShutdownHookAndBlock(service);
   }
 }

--- a/src/main/java/io/confluent/examples/streams/microservices/ValidationsAggregatorService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/ValidationsAggregatorService.java
@@ -56,14 +56,16 @@ public class ValidationsAggregatorService implements Service {
   private KafkaStreams streams;
 
   @Override
-  public void start(String bootstrapServers, String stateDir) {
+  public void start(final String bootstrapServers, final String stateDir) {
     streams = aggregateOrderValidations(bootstrapServers, stateDir);
     streams.cleanUp(); //don't do this in prod as it clears your state stores
     streams.start();
     log.info("Started Service " + getClass().getSimpleName());
   }
 
-  private KafkaStreams aggregateOrderValidations(String bootstrapServers, String stateDir) {
+  private KafkaStreams aggregateOrderValidations(
+      final String bootstrapServers,
+      final String stateDir) {
     final int numberOfRules = 3; //TODO put into a KTable to make dynamically configurable
 
     StreamsBuilder builder = new StreamsBuilder();

--- a/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
+++ b/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
@@ -117,6 +117,7 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     effectiveConfig.put(KafkaConfig$.MODULE$.LogCleanerDedupeBufferSizeProp(), 2 * 1024 * 1024L);
     effectiveConfig.put(KafkaConfig$.MODULE$.GroupMinSessionTimeoutMsProp(), 0);
     effectiveConfig.put(KafkaConfig$.MODULE$.OffsetsTopicReplicationFactorProp(), (short) 1);
+    effectiveConfig.put(KafkaConfig$.MODULE$.OffsetsTopicPartitionsProp(), 1);
     effectiveConfig.put(KafkaConfig$.MODULE$.AutoCreateTopicsEnableProp(), true);
     return effectiveConfig;
   }

--- a/src/test/java/io/confluent/examples/streams/microservices/EmailServiceTest.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/EmailServiceTest.java
@@ -63,9 +63,9 @@ public class EmailServiceTest extends MicroserviceTestUtils {
     send(Topics.PAYMENTS, Collections.singleton(new KeyValue<>(payment.getId(), payment)));
 
     //When
-    emailService.start(CLUSTER.bootstrapServers());
+    emailService.start(CLUSTER.bootstrapServers(), TestUtils.tempDirectory().getPath());
 
     //Then
-    TestUtils.waitForCondition(() -> complete, "Email was never sent.");
+    TestUtils.waitForCondition(() -> complete, 30000, "Email was never sent.");
   }
 }

--- a/src/test/java/io/confluent/examples/streams/microservices/EndToEndTest.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/EndToEndTest.java
@@ -8,6 +8,7 @@ import io.confluent.examples.streams.microservices.domain.beans.OrderBean;
 import io.confluent.examples.streams.microservices.util.MicroserviceTestUtils;
 import io.confluent.examples.streams.microservices.util.Paths;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.test.TestUtils;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.junit.After;
@@ -43,7 +44,7 @@ public class EndToEndTest extends MicroserviceTestUtils {
   private Client client;
 
   @Test
-  public void shouldCreateNewOrderAndGetBackValidatedOrder() throws Exception {
+  public void shouldCreateNewOrderAndGetBackValidatedOrder() {
     OrderBean inputOrder = new OrderBean(id(1L), 2L, OrderState.CREATED, Product.JUMPERS, 1, 1d);
     client = getClient();
 
@@ -64,7 +65,7 @@ public class EndToEndTest extends MicroserviceTestUtils {
   }
 
   @Test
-  public void shouldProcessManyValidOrdersEndToEnd() throws Exception {
+  public void shouldProcessManyValidOrdersEndToEnd() {
     client = getClient();
 
     //Add inventory required by the inventory service
@@ -99,7 +100,7 @@ public class EndToEndTest extends MicroserviceTestUtils {
   }
 
   @Test
-  public void shouldProcessManyInvalidOrdersEndToEnd() throws Exception {
+  public void shouldProcessManyInvalidOrdersEndToEnd() {
     client = getClient();
 
     //Add inventory required by the inventory service
@@ -163,16 +164,16 @@ public class EndToEndTest extends MicroserviceTestUtils {
     services.add(new ValidationsAggregatorService());
 
     tailAllTopicsToConsole(CLUSTER.bootstrapServers());
-    services.forEach(s -> s.start(CLUSTER.bootstrapServers()));
+    services.forEach(s -> s.start(CLUSTER.bootstrapServers(), TestUtils.tempDirectory().getPath()));
 
     final OrdersService ordersService = new OrdersService(HOST, restPort);
-    ordersService.start(CLUSTER.bootstrapServers());
+    ordersService.start(CLUSTER.bootstrapServers(), TestUtils.tempDirectory().getPath());
     path = new Paths("localhost", ordersService.port());
     services.add(ordersService);
   }
 
   @After
-  public void tearDown() throws Exception {
+  public void tearDown() {
     services.forEach(Service::stop);
     stopTailers();
     CLUSTER.stop();

--- a/src/test/java/io/confluent/examples/streams/microservices/FraudServiceTest.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/FraudServiceTest.java
@@ -4,6 +4,8 @@ import io.confluent.examples.streams.avro.microservices.Order;
 import io.confluent.examples.streams.avro.microservices.OrderValidation;
 import io.confluent.examples.streams.microservices.domain.Schemas;
 import io.confluent.examples.streams.microservices.util.MicroserviceTestUtils;
+
+import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -60,7 +62,7 @@ public class FraudServiceTest extends MicroserviceTestUtils {
     sendOrders(orders);
 
     //When
-    fraudService.start(CLUSTER.bootstrapServers());
+    fraudService.start(CLUSTER.bootstrapServers(), TestUtils.tempDirectory().getPath());
 
     //Then there should be failures for the two orders that push customers over their limit.
     List<OrderValidation> expected = asList(

--- a/src/test/java/io/confluent/examples/streams/microservices/InventoryServiceTest.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/InventoryServiceTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
+import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -37,7 +38,7 @@ public class InventoryServiceTest extends MicroserviceTestUtils {
 
 
   @BeforeClass
-  public static void startKafkaCluster() throws Exception {
+  public static void startKafkaCluster() {
     CLUSTER.createTopic(Topics.ORDERS.name());
     CLUSTER.createTopic(Topics.ORDER_VALIDATIONS.name());
     Schemas.configureSerdesWithSchemaRegistryUrl(CLUSTER.schemaRegistryUrl());
@@ -64,7 +65,7 @@ public class InventoryServiceTest extends MicroserviceTestUtils {
     sendOrders(orders);
 
     //When
-    inventoryService.start(CLUSTER.bootstrapServers());
+    inventoryService.start(CLUSTER.bootstrapServers(), TestUtils.tempDirectory().getPath());
 
     //Then the final order for Jumpers should have been 'rejected' as it's out of stock
     expected = asList(

--- a/src/test/java/io/confluent/examples/streams/microservices/OrdersServiceTest.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/OrdersServiceTest.java
@@ -8,6 +8,8 @@ import io.confluent.examples.streams.microservices.domain.Schemas.Topics;
 import io.confluent.examples.streams.microservices.domain.beans.OrderBean;
 import io.confluent.examples.streams.microservices.util.MicroserviceTestUtils;
 import io.confluent.examples.streams.microservices.util.Paths;
+
+import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -66,7 +68,7 @@ public class OrdersServiceTest extends MicroserviceTestUtils {
 
     //Given a rest service
     rest = new OrdersService("localhost");
-    rest.start(CLUSTER.bootstrapServers());
+    rest.start(CLUSTER.bootstrapServers(), TestUtils.tempDirectory().getPath());
     Paths paths = new Paths("localhost", rest.port());
 
     //When we POST an order
@@ -108,7 +110,7 @@ public class OrdersServiceTest extends MicroserviceTestUtils {
 
     //Given a rest service
     rest = new OrdersService("localhost");
-    rest.start(CLUSTER.bootstrapServers());
+    rest.start(CLUSTER.bootstrapServers(), TestUtils.tempDirectory().getPath());
     Paths paths = new Paths("localhost", rest.port());
 
     //When we post an order
@@ -139,7 +141,7 @@ public class OrdersServiceTest extends MicroserviceTestUtils {
 
     //Start the rest interface
     rest = new OrdersService("localhost");
-    rest.start(CLUSTER.bootstrapServers());
+    rest.start(CLUSTER.bootstrapServers(), TestUtils.tempDirectory().getPath());
     Paths paths = new Paths("localhost", rest.port());
 
     //Then GET order should timeout
@@ -162,10 +164,10 @@ public class OrdersServiceTest extends MicroserviceTestUtils {
 
     //Given two rest servers on different ports
     rest = new OrdersService("localhost");
-    rest.start(CLUSTER.bootstrapServers());
+    rest.start(CLUSTER.bootstrapServers(), TestUtils.tempDirectory().getPath());
     Paths paths1 = new Paths("localhost", rest.port());
     rest2 = new OrdersService("localhost");
-    rest2.start(CLUSTER.bootstrapServers());
+    rest2.start(CLUSTER.bootstrapServers(), TestUtils.tempDirectory().getPath());
     Paths paths2 = new Paths("localhost", rest2.port());
 
     //And one order

--- a/src/test/java/io/confluent/examples/streams/microservices/ValidationsAggregatorServiceTest.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/ValidationsAggregatorServiceTest.java
@@ -19,6 +19,7 @@ import io.confluent.examples.streams.microservices.util.MicroserviceTestUtils;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -31,7 +32,7 @@ public class ValidationsAggregatorServiceTest extends MicroserviceTestUtils {
 
 
   @BeforeClass
-  public static void startKafkaCluster() throws Exception {
+  public static void startKafkaCluster() {
     CLUSTER.createTopic(Topics.ORDERS.name());
     CLUSTER.createTopic(Topics.ORDER_VALIDATIONS.name());
     Schemas.configureSerdesWithSchemaRegistryUrl(CLUSTER.schemaRegistryUrl());
@@ -61,7 +62,7 @@ public class ValidationsAggregatorServiceTest extends MicroserviceTestUtils {
     sendOrderValuations(ruleResults);
 
     //When
-    ordersService.start(CLUSTER.bootstrapServers());
+    ordersService.start(CLUSTER.bootstrapServers(), TestUtils.tempDirectory().getPath());
 
     //Then
     List<KeyValue<String, Order>> finalOrders = MicroserviceTestUtils


### PR DESCRIPTION
Change the microservices tests etc to not use /tmp/kafka-streams.
Increased timeout in `EmailServiceTest` to 30 seconds
Reduce number of consumer-offset partitions in `EmbeddedKafka` as 50 is overkill for tests.