### PR TITLE
Use CP 4.1.0 docker images for 4.1 branches

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:4.1.0
     hostname: zookeeper
     ports:
       - '32181:32181'
@@ -13,7 +13,7 @@ services:
       - "moby:127.0.0.1"
 
   kafka:
-    image: confluentinc/cp-enterprise-kafka:latest
+    image: confluentinc/cp-enterprise-kafka:4.1.0
     hostname: kafka
     ports:
       - '9092:9092'
@@ -39,7 +39,7 @@ services:
       - "moby:127.0.0.1"
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:latest
+    image: confluentinc/cp-schema-registry:4.1.0
     hostname: schema-registry
     depends_on:
       - zookeeper
@@ -55,7 +55,7 @@ services:
   # This "container" is a workaround to pre-create topics for the Kafka Music application
   # until we have a more elegant way to do that.
   kafka-create-topics:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:4.1.0
     depends_on:
       - kafka
     hostname: kafka-create-topics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
 
   # Continuously generates input data for the Kafka Music application.
   kafka-music-data-generator:
-    image: confluentinc/kafka-streams-examples:4.0.0
+    image: confluentinc/kafka-streams-examples:4.1.0
     hostname: kafka-music-data-generator
     depends_on:
       - kafka
@@ -90,7 +90,7 @@ services:
                        cub kafka-ready -b kafka:29092 1 20 && \
                        echo Waiting for Confluent Schema Registry to be ready... && \
                        cub sr-ready schema-registry 8081 20 && \
-                       java -cp /usr/share/java/kafka-streams-examples/kafka-streams-examples-4.0.0-standalone.jar \
+                       java -cp /usr/share/java/kafka-streams-examples/kafka-streams-examples-4.1.0-standalone.jar \
                        io.confluent.examples.streams.interactivequeries.kafkamusic.KafkaMusicExampleDriver \
                        kafka:29092 http://schema-registry:8081'"
     environment:
@@ -104,7 +104,7 @@ services:
 
   # Runs the Kafka Music application.
   kafka-music-application:
-    image: confluentinc/kafka-streams-examples:4.0.0
+    image: confluentinc/kafka-streams-examples:4.1.0
     hostname: kafka-music-application
     depends_on:
       - kafka


### PR DESCRIPTION
**Important:** This PR must only be merged once we published a 4.1.0 tagged image for https://hub.docker.com/r/confluentinc/kafka-streams-examples/.

