### PR TITLE
Fixed host issue for kafka-interactive-queries

### DIFF
--- a/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java
@@ -202,9 +202,9 @@ public class WordCountInteractiveQueriesExample {
   }
 
 
-  static WordCountInteractiveQueriesRestService startRestProxy(final KafkaStreams streams, final int port, final
-                                                               String host)
-      throws Exception {
+  static WordCountInteractiveQueriesRestService startRestProxy(final KafkaStreams streams,
+                                                               final int port,
+                                                               final String host) throws Exception {
     final HostInfo hostInfo = new HostInfo(host, port);
     final WordCountInteractiveQueriesRestService
         wordCountInteractiveQueriesRestService = new WordCountInteractiveQueriesRestService(streams, hostInfo);

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java
@@ -83,7 +83,7 @@ import java.util.Properties;
  * <pre>
  * {@code
  * $ java -cp target/kafka-streams-examples-4.0.0-SNAPSHOT-standalone.jar \
- *      io.confluent.examples.streams.interactivequeries.InteractiveQueriesExample 7070
+ *      io.confluent.examples.streams.interactivequeries.WordCountInteractiveQueriesExample 7070
  * }
  * </pre>
  *
@@ -94,7 +94,7 @@ import java.util.Properties;
  * <pre>
  * {@code
  * $ java -cp target/kafka-streams-examples-4.0.0-SNAPSHOT-standalone.jar \
- *      io.confluent.examples.streams.interactivequeries.InteractiveQueriesExample 7071
+ *      io.confluent.examples.streams.interactivequeries.WordCountInteractiveQueriesExample 7071
  * }
  * </pre>
  *
@@ -166,7 +166,7 @@ public class WordCountInteractiveQueriesExample {
     streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
     // Provide the details of our embedded http service that we'll use to connect to this streams
     // instance and discover locations of stores.
-    streamsConfiguration.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + port);
+    streamsConfiguration.put(StreamsConfig.APPLICATION_SERVER_CONFIG, DEFAULT_HOST + ":" + port);
     final File example = Files.createTempDirectory(new File("/tmp").toPath(), "example").toFile();
     streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, example.getPath());
 
@@ -188,7 +188,7 @@ public class WordCountInteractiveQueriesExample {
     streams.start();
 
     // Start the Restful proxy for servicing remote access to state stores
-    final WordCountInteractiveQueriesRestService restService = startRestProxy(streams, port);
+    final WordCountInteractiveQueriesRestService restService = startRestProxy(streams, port, DEFAULT_HOST);
 
     // Add shutdown hook to respond to SIGTERM and gracefully close Kafka Streams
     Runtime.getRuntime().addShutdownHook(new Thread(() -> {
@@ -202,9 +202,10 @@ public class WordCountInteractiveQueriesExample {
   }
 
 
-  static WordCountInteractiveQueriesRestService startRestProxy(final KafkaStreams streams, final int port)
+  static WordCountInteractiveQueriesRestService startRestProxy(final KafkaStreams streams, final int port, final
+                                                               String host)
       throws Exception {
-    final HostInfo hostInfo = new HostInfo(DEFAULT_HOST, port);
+    final HostInfo hostInfo = new HostInfo(host, port);
     final WordCountInteractiveQueriesRestService
         wordCountInteractiveQueriesRestService = new WordCountInteractiveQueriesRestService(streams, hostInfo);
     wordCountInteractiveQueriesRestService.start(port);

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesRestService.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesRestService.java
@@ -276,7 +276,7 @@ public class WordCountInteractiveQueriesRestService {
       jettyServer.start();
     } catch (java.net.SocketException exception) {
       log.error("Unavailable: " + hostInfo.host() + ":" + hostInfo.port());
-      throw new Exception(exception.getMessage());
+      throw new Exception(exception.toString());
     }
   }
 

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesRestService.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesRestService.java
@@ -265,7 +265,7 @@ public class WordCountInteractiveQueriesRestService {
     ServletHolder holder = new ServletHolder(sc);
     context.addServlet(holder, "/*");
     
-    ServerConnector connector = new ServerConnector(jettyServer);
+    final ServerConnector connector = new ServerConnector(jettyServer);
     connector.setHost(hostInfo.host());
     connector.setPort(port);
     jettyServer.addConnector(connector);
@@ -274,7 +274,7 @@ public class WordCountInteractiveQueriesRestService {
     
     try {
       jettyServer.start();
-    } catch (java.net.SocketException exception) {
+    } catch (final java.net.SocketException exception) {
       log.error("Unavailable: " + hostInfo.host() + ":" + hostInfo.port());
       throw new Exception(exception.toString());
     }

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExample.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExample.java
@@ -200,7 +200,8 @@ public class KafkaMusicExample {
     final KafkaStreams streams = createChartsStreams(bootstrapServers,
                                                      schemaRegistryUrl,
                                                      restEndpointPort,
-                                                     "/tmp/kafka-streams");
+                                                     "/tmp/kafka-streams",
+                                                     restEndpointHostname);
 
     // Always (and unconditionally) clean local state prior to starting the processing topology.
     // We opt for this unconditional call here because this will make it easier for you to play around with the example
@@ -244,7 +245,8 @@ public class KafkaMusicExample {
   static KafkaStreams createChartsStreams(final String bootstrapServers,
                                           final String schemaRegistryUrl,
                                           final int applicationServerPort,
-                                          final String stateDir) {
+                                          final String stateDir,
+                                          final String host) {
     final Properties streamsConfiguration = new Properties();
     // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
     // against which the application is run.
@@ -253,7 +255,7 @@ public class KafkaMusicExample {
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     // Provide the details of our embedded http service that we'll use to connect to this streams
     // instance and discover locations of stores.
-    streamsConfiguration.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + applicationServerPort);
+    streamsConfiguration.put(StreamsConfig.APPLICATION_SERVER_CONFIG, host + ":" + applicationServerPort);
     streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, stateDir);
     // Set to earliest so we don't miss any data that arrived in the topics before the process
     // started

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/MusicPlaysRestService.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/MusicPlaysRestService.java
@@ -236,7 +236,7 @@ public class MusicPlaysRestService {
       jettyServer.start();
     } catch (java.net.SocketException exception) {
       log.error("Unavailable: " + hostInfo.host() + ":" + hostInfo.port());
-      throw new Exception(exception.getMessage());
+      throw new Exception(exception.toString());
     }
   }
 

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/MusicPlaysRestService.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/MusicPlaysRestService.java
@@ -225,7 +225,7 @@ public class MusicPlaysRestService {
     ServletHolder holder = new ServletHolder(sc);
     context.addServlet(holder, "/*");
   
-    ServerConnector connector = new ServerConnector(jettyServer);
+    final ServerConnector connector = new ServerConnector(jettyServer);
     connector.setHost(hostInfo.host());
     connector.setPort(hostInfo.port());
     jettyServer.addConnector(connector);
@@ -234,7 +234,7 @@ public class MusicPlaysRestService {
   
     try {
       jettyServer.start();
-    } catch (java.net.SocketException exception) {
+    } catch (final java.net.SocketException exception) {
       log.error("Unavailable: " + hostInfo.host() + ":" + hostInfo.port());
       throw new Exception(exception.toString());
     }

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/MusicPlaysRestService.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/MusicPlaysRestService.java
@@ -25,11 +25,14 @@ import org.apache.kafka.streams.state.HostInfo;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
@@ -57,6 +60,7 @@ public class MusicPlaysRestService {
   private final Client client = ClientBuilder.newBuilder().register(JacksonFeature.class).build();
   private Server jettyServer;
   private LongSerializer serializer = new LongSerializer();
+  private static final Logger log = LoggerFactory.getLogger(MusicPlaysRestService.class);
 
 
   MusicPlaysRestService(final KafkaStreams streams, final HostInfo hostInfo) {
@@ -210,7 +214,7 @@ public class MusicPlaysRestService {
     ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
     context.setContextPath("/");
 
-    jettyServer = new Server(hostInfo.port());
+    jettyServer = new Server();
     jettyServer.setHandler(context);
 
     ResourceConfig rc = new ResourceConfig();
@@ -220,8 +224,20 @@ public class MusicPlaysRestService {
     ServletContainer sc = new ServletContainer(rc);
     ServletHolder holder = new ServletHolder(sc);
     context.addServlet(holder, "/*");
-
-    jettyServer.start();
+  
+    ServerConnector connector = new ServerConnector(jettyServer);
+    connector.setHost(hostInfo.host());
+    connector.setPort(hostInfo.port());
+    jettyServer.addConnector(connector);
+  
+    context.start();
+  
+    try {
+      jettyServer.start();
+    } catch (java.net.SocketException exception) {
+      log.error("Unavailable: " + hostInfo.host() + ":" + hostInfo.port());
+      throw new Exception(exception.getMessage());
+    }
   }
 
   /**

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
@@ -69,6 +69,14 @@ public class WordCountInteractiveQueriesExampleTest {
       "interactive-queries-wordcount-example-word-count-changelog";
   private static final String WINDOWED_WORD_COUNT_OUTPUT =
       "interactive-queries-wordcount-example-windowed-word-count-changelog";
+  
+  private static final List<String> inputValues = Arrays.asList("hello",
+          "world",
+          "world",
+          "hello world",
+          "all streams lead to kafka",
+          "streams",
+          "kafka streams");
 
   @Rule
   public final TemporaryFolder temp = new TemporaryFolder();
@@ -76,7 +84,7 @@ public class WordCountInteractiveQueriesExampleTest {
   private WordCountInteractiveQueriesRestService proxy;
 
   @BeforeClass
-  public static void createTopic() {
+  public static void createTopicsAndProduceDataToInputTopics() throws Exception {
     CLUSTER.createTopic(WordCountInteractiveQueriesExample.TEXT_LINES_TOPIC, 2, 1);
     // The next two topics don't need to be created as they would be auto-created
     // by Kafka Streams, but it just makes the test more reliable if they already exist
@@ -84,6 +92,17 @@ public class WordCountInteractiveQueriesExampleTest {
     // the timing quite difficult...
     CLUSTER.createTopic(WORD_COUNT, 2, 1);
     CLUSTER.createTopic(WINDOWED_WORD_COUNT, 2, 1);
+  
+    // Produce sample data to the input topic before the tests starts.
+    Properties producerConfig = new Properties();
+    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+    producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
+    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
+    producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    IntegrationTestUtils
+            .produceValuesSynchronously(WordCountInteractiveQueriesExample.TEXT_LINES_TOPIC, inputValues,
+                    producerConfig);
   }
 
   @After
@@ -106,31 +125,14 @@ public class WordCountInteractiveQueriesExampleTest {
 
   @Test
   public void shouldDemonstrateInteractiveQueries() throws Exception {
-    final List<String> inputValues = Arrays.asList("hello",
-        "world",
-        "world",
-        "hello world",
-        "all streams lead to kafka",
-        "streams",
-        "kafka streams");
-
-    Properties producerConfig = new Properties();
-    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
-    producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-    producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-    IntegrationTestUtils
-        .produceValuesSynchronously(WordCountInteractiveQueriesExample.TEXT_LINES_TOPIC, inputValues,
-                                    producerConfig);
-
     // Race condition caveat:  This two-step approach of finding a free port but not immediately
     // binding to it may cause occasional errors.
     final int port = randomFreeLocalPort();
-    final String baseUrl = "http://localhost:" + port + "/state";
+    final String host = "localhost";
+    final String baseUrl = "http://" + host + ":" + port + "/state";
 
     kafkaStreams = WordCountInteractiveQueriesExample.createStreams(
-        createStreamConfig(CLUSTER.bootstrapServers(), port, "one"));
+        createStreamConfig(CLUSTER.bootstrapServers(), port, "one", host));
 
     final CountDownLatch startupLatch = new CountDownLatch(1);
     kafkaStreams.setStateListener((newState, oldState) -> {
@@ -139,7 +141,8 @@ public class WordCountInteractiveQueriesExampleTest {
         }
     });
     kafkaStreams.start();
-    proxy = WordCountInteractiveQueriesExample.startRestProxy(kafkaStreams, port);
+    // Starts the Rest Service on the provided host:port
+    proxy = WordCountInteractiveQueriesExample.startRestProxy(kafkaStreams, port, host);
 
     assertTrue("streams failed to start within timeout", startupLatch.await(30, TimeUnit.SECONDS));
 
@@ -236,6 +239,145 @@ public class WordCountInteractiveQueriesExampleTest {
     assertTrue(keyValueBean.getKey().startsWith("streams"));
     assertThat(keyValueBean.getValue(), equalTo(3L));
   }
+  
+  @Test
+  public void shouldStartRestApiOnAnyValidHost() throws Exception {
+    // Race condition caveat:  This two-step approach of finding a free port but not immediately
+    // binding to it may cause occasional errors.
+    final int port = randomFreeLocalPort();
+    
+    // Any valid host or IP.
+    final String host = "127.10.10.10";
+    final String baseUrl = "http://" + host + ":" + port + "/state";
+
+    kafkaStreams = WordCountInteractiveQueriesExample.createStreams(
+        createStreamConfig(CLUSTER.bootstrapServers(), port, "one", host));
+
+    final CountDownLatch startupLatch = new CountDownLatch(1);
+    kafkaStreams.setStateListener((newState, oldState) -> {
+        if (newState == KafkaStreams.State.RUNNING && oldState == KafkaStreams.State.REBALANCING) {
+          startupLatch.countDown();
+        }
+    });
+    kafkaStreams.start();
+    // Starts the Rest Service on the provided host:port
+    proxy = WordCountInteractiveQueriesExample.startRestProxy(kafkaStreams, port, host);
+
+    assertTrue("streams failed to start within timeout", startupLatch.await(30, TimeUnit.SECONDS));
+
+    final Client client = ClientBuilder.newClient();
+
+    // Create a request to fetch all instances of HostStoreInfo
+    final Invocation.Builder allInstancesRequest = client.target(baseUrl + "/instances")
+        .request(MediaType.APPLICATION_JSON_TYPE);
+    final List<HostStoreInfo> hostStoreInfo = fetchHostInfo(allInstancesRequest);
+
+    assertThat(hostStoreInfo, hasItem(
+        new HostStoreInfo("127.10.10.10", port, Sets.newHashSet("word-count", "windowed-word-count"))
+    ));
+
+    // Create a request to fetch all instances with word-count
+    final Invocation.Builder wordCountInstancesRequest = client.target(baseUrl + "/instances/word-count")
+        .request(MediaType.APPLICATION_JSON_TYPE);
+    final List<HostStoreInfo>
+        wordCountInstances = fetchHostInfo(wordCountInstancesRequest);
+
+    assertThat(wordCountInstances, hasItem(
+        new HostStoreInfo("127.10.10.10", port, Sets.newHashSet("word-count", "windowed-word-count"))
+    ));
+
+    Properties consumerConfig = new Properties();
+    consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+    consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+    consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+    consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "wait-for-output-consumer-new-host");
+    consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerConfig, WORD_COUNT_OUTPUT, inputValues.size());
+    IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerConfig, WINDOWED_WORD_COUNT_OUTPUT, inputValues.size());
+
+    // Fetch all key-value pairs from the word-count store
+    final Invocation.Builder
+        allRequest =
+        client.target(baseUrl + "/keyvalues/word-count/all")
+            .request(MediaType.APPLICATION_JSON_TYPE);
+
+    final List<KeyValueBean>
+        allValues =
+        Arrays.asList(new KeyValueBean("all", 1L),
+            new KeyValueBean("hello", 2L),
+            new KeyValueBean("kafka", 2L),
+            new KeyValueBean("lead", 1L),
+            new KeyValueBean("streams", 3L),
+            new KeyValueBean("to", 1L),
+            new KeyValueBean("world", 3L));
+    final List<KeyValueBean>
+        all = fetchRangeOfValues(allRequest,
+        allValues);
+    assertThat(all, equalTo(allValues));
+
+    // Fetch a range of key-value pairs from the word-count store
+    final List<KeyValueBean> expectedRange = Arrays.asList(
+        new KeyValueBean("all", 1L),
+        new KeyValueBean("hello", 2L),
+        new KeyValueBean("kafka", 2L));
+
+    final Invocation.Builder
+        request =
+        client.target(baseUrl + "/keyvalues/word-count/range/all/kafka")
+            .request(MediaType.APPLICATION_JSON_TYPE);
+    final List<KeyValueBean>
+        range = fetchRangeOfValues(request, expectedRange);
+
+    assertThat(range, equalTo(expectedRange));
+
+    // Find the instance of the Kafka Streams application that would have the key hello
+    final HostStoreInfo
+        hostWithHelloKey =
+        client.target(baseUrl + "/instance/word-count/hello")
+            .request(MediaType.APPLICATION_JSON_TYPE).get(HostStoreInfo.class);
+
+    // Fetch the value for the key hello from the instance.
+    final KeyValueBean result = client.target("http://" + hostWithHelloKey.getHost() +
+        ":" + hostWithHelloKey.getPort() +
+        "/state/keyvalue/word-count/hello")
+        .request(MediaType.APPLICATION_JSON_TYPE).get(KeyValueBean.class);
+
+    assertThat(result, equalTo(new KeyValueBean("hello", 2L)));
+
+    // fetch windowed values for a key
+    final List<KeyValueBean>
+        windowedResult =
+        client.target(baseUrl + "/windowed/windowed-word-count/streams/0/" + System
+            .currentTimeMillis())
+            .request(MediaType.APPLICATION_JSON_TYPE)
+
+            .get(new GenericType<List<KeyValueBean>>() {
+            });
+    assertThat(windowedResult.size(), equalTo(1));
+    final KeyValueBean keyValueBean = windowedResult.get(0);
+    assertTrue(keyValueBean.getKey().startsWith("streams"));
+    assertThat(keyValueBean.getValue(), equalTo(3L));
+  }
+  
+  @Test(expected = Exception.class)
+  public void shouldThrowExceptionForInvalidHost() throws Exception {
+    final int port = randomFreeLocalPort();
+    final String host = "someInvalidHost";
+    final String baseUrl = "http://" + host + ":" + port + "/state";
+    
+    kafkaStreams = WordCountInteractiveQueriesExample.createStreams(
+            createStreamConfig(CLUSTER.bootstrapServers(), port, "one", host));
+    
+    final CountDownLatch startupLatch = new CountDownLatch(1);
+    kafkaStreams.setStateListener((newState, oldState) -> {
+      if (newState == KafkaStreams.State.RUNNING && oldState == KafkaStreams.State.REBALANCING) {
+        startupLatch.countDown();
+      }
+    });
+    
+    kafkaStreams.start();
+    proxy = WordCountInteractiveQueriesExample.startRestProxy(kafkaStreams, port, host);
+  }
 
   /**
    * We fetch these in a loop as they are the first couple of requests
@@ -276,7 +418,8 @@ public class WordCountInteractiveQueriesExampleTest {
 
   private Properties createStreamConfig(final String bootStrap,
                                         final int port,
-                                        final String stateDir)
+                                        final String stateDir,
+                                        final String host)
       throws
       IOException {
     Properties streamsConfiguration = new Properties();
@@ -286,7 +429,7 @@ public class WordCountInteractiveQueriesExampleTest {
     // Where to find Kafka broker(s).
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootStrap);
     // The host:port the embedded REST proxy will run on
-    streamsConfiguration.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:" + port);
+    streamsConfiguration.put(StreamsConfig.APPLICATION_SERVER_CONFIG, host + ":" + port);
     // The directory where the RocksDB State Stores will reside
     streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, temp.newFolder(stateDir).getPath());
     // Set the default key serde

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
@@ -52,6 +52,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -101,7 +102,7 @@ public class WordCountInteractiveQueriesExampleTest {
     CLUSTER.createTopic(WINDOWED_WORD_COUNT, 2, 1);
   
     // Produce sample data to the input topic before the tests starts.
-    Properties producerConfig = new Properties();
+    final Properties producerConfig = new Properties();
     producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
     producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
     producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
@@ -244,6 +245,8 @@ public class WordCountInteractiveQueriesExampleTest {
       final KeyValueBean keyValueBean = windowedResult.get(0);
       assertTrue(keyValueBean.getKey().startsWith("streams"));
       assertThat(keyValueBean.getValue(), equalTo(3L));
+    } else {
+        fail("Should fail demonstrating InteractiveQueries as the Rest Service failed to start.");
     }
   }
   
@@ -255,7 +258,7 @@ public class WordCountInteractiveQueriesExampleTest {
         // Starts the Rest Service on the provided host:port
         proxy = WordCountInteractiveQueriesExample.startRestProxy(kafkaStreams, port, host);
       } catch (Exception ex) {
-        log.error(ex.toString());
+        log.error("Could not start Rest Service due to: " + ex.toString());
       }
       count++;
     }
@@ -377,6 +380,8 @@ public class WordCountInteractiveQueriesExampleTest {
       final KeyValueBean keyValueBean = windowedResult.get(0);
       assertTrue(keyValueBean.getKey().startsWith("streams"));
       assertThat(keyValueBean.getValue(), equalTo(3L));
+    } else {
+        fail("Should fail demonstrating InteractiveQueries on any valid host as the Rest Service failed to start.");
     }
   }
   
@@ -401,9 +406,6 @@ public class WordCountInteractiveQueriesExampleTest {
   
   @Test
   public void shouldThrowBindExceptionForUnavailablePort() throws Exception {
-    expectedEx.expect(Exception.class);
-    expectedEx.expectMessage("java.net.BindException: Address already in use");
-    
     final int port = randomFreeLocalPort();
     final String host = "localhost";
     
@@ -419,6 +421,8 @@ public class WordCountInteractiveQueriesExampleTest {
     
     kafkaStreams.start();
     proxy = WordCountInteractiveQueriesExample.startRestProxy(kafkaStreams, port, host);
+    expectedEx.expect(Exception.class);
+    expectedEx.expectMessage("java.net.BindException: Address already in use");
     // Binding to same port again will raise BindException.
     WordCountInteractiveQueriesExample.startRestProxy(kafkaStreams, port, host);
   }

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
@@ -246,7 +246,7 @@ public class WordCountInteractiveQueriesExampleTest {
       assertTrue(keyValueBean.getKey().startsWith("streams"));
       assertThat(keyValueBean.getValue(), equalTo(3L));
     } else {
-        fail("Should fail demonstrating InteractiveQueries as the Rest Service failed to start.");
+      fail("Should fail demonstrating InteractiveQueries as the Rest Service failed to start.");
     }
   }
   
@@ -381,7 +381,7 @@ public class WordCountInteractiveQueriesExampleTest {
       assertTrue(keyValueBean.getKey().startsWith("streams"));
       assertThat(keyValueBean.getValue(), equalTo(3L));
     } else {
-        fail("Should fail demonstrating InteractiveQueries on any valid host as the Rest Service failed to start.");
+      fail("Should fail demonstrating InteractiveQueries on any valid host as the Rest Service failed to start.");
     }
   }
   

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
@@ -32,7 +32,6 @@ import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.StreamsMetadata;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -67,9 +66,71 @@ public class KafkaMusicExampleTest {
   private KafkaStreams streams;
   private MusicPlaysRestService restProxy;
   private int appServerPort;
+  private static final List<Song> songs = Arrays.asList(new Song(1L,
+                                                                 "Fresh Fruit For Rotting Vegetables",
+                                                                 "Dead Kennedys",
+                                                                 "Chemical Warfare",
+                                                                 "Punk"),
+                                                        new Song(2L,
+                                                                 "We Are the League",
+                                                                 "Anti-Nowhere League",
+                                                                 "Animal",
+                                                                 "Punk"),
+                                                        new Song(3L,
+                                                                 "Live In A Dive",
+                                                                 "Subhumans",
+                                                                 "All Gone Dead",
+                                                                 "Punk"),
+                                                        new Song(4L,
+                                                                 "PSI",
+                                                                 "Wheres The Pope?",
+                                                                 "Fear Of God",
+                                                                 "Punk"),
+                                                        new Song(5L,
+                                                                 "Totally Exploited",
+                                                                 "The Exploited",
+                                                                 "Punks Not Dead",
+                                                                 "Punk"),
+                                                        new Song(6L,
+                                                                 "The Audacity Of Hype",
+                                                                 "Jello Biafra And The Guantanamo School Of "
+                                                                         + "Medicine",
+                                                                 "Three Strikes",
+                                                                 "Punk"),
+                                                        new Song(7L,
+                                                                 "Licensed to Ill",
+                                                                 "The Beastie Boys",
+                                                                 "Fight For Your Right",
+                                                                 "Hip Hop"),
+                                                        new Song(8L,
+                                                                 "De La Soul Is Dead",
+                                                                 "De La Soul",
+                                                                 "Oodles Of O's",
+                                                                 "Hip Hop"),
+                                                        new Song(9L,
+                                                                 "Straight Outta Compton",
+                                                                 "N.W.A",
+                                                                 "Gangsta Gangsta",
+                                                                 "Hip Hop"),
+                                                        new Song(10L,
+                                                                 "Fear Of A Black Planet",
+                                                                 "Public Enemy",
+                                                                 "911 Is A Joke",
+                                                                 "Hip Hop"),
+                                                        new Song(11L,
+                                                                 "Curtain Call - The Hits",
+                                                                 "Eminem",
+                                                                 "Fack",
+                                                                 "Hip Hop"),
+                                                        new Song(12L,
+                                                                 "The Calling",
+                                                                 "Hilltop Hoods",
+                                                                 "The Calling",
+                                                                 "Hip Hop")
+                                                        );
 
   @BeforeClass
-  public static void createTopics() {
+  public static void createTopicsAndProduceDataToInputTopics() {
     CLUSTER.createTopic(KafkaMusicExample.PLAY_EVENTS);
     CLUSTER.createTopic(KafkaMusicExample.SONG_FEED);
     // these topics initialized just to avoid some rebalances.
@@ -81,111 +142,28 @@ public class KafkaMusicExampleTest {
     CLUSTER.createTopic("kafka-music-charts-top-five-songs-changelog");
     CLUSTER.createTopic("kafka-music-charts-top-five-songs-repartition");
     CLUSTER.createTopic("kafka-music-charts-KSTREAM-MAP-0000000004-repartition");
-  }
-
-  @Before
-  public void createStreams() throws Exception {
-    appServerPort = randomFreeLocalPort();
-    streams =
-        KafkaMusicExample.createChartsStreams(CLUSTER.bootstrapServers(),
-                                              CLUSTER.schemaRegistryUrl(),
-                                              appServerPort,
-                                              TestUtils.tempDirectory().getPath());
-    restProxy = KafkaMusicExample.startRestProxy(streams, new HostInfo("localhost", appServerPort));
-  }
-
-  @After
-  public void shutdown() throws Exception {
-    restProxy.stop();
-    streams.close();
-  }
-
-  @Test
-  public void shouldCreateChartsAndAccessThemViaInteractiveQueries() throws Exception {
+  
+    // Produce sample data to the input topic before the tests starts.
     final Properties props = new Properties();
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-
+  
     final Map<String, String> serdeConfig = Collections.singletonMap(
         AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, CLUSTER.schemaRegistryUrl());
-
+  
     final SpecificAvroSerializer<PlayEvent> playEventSerializer = new SpecificAvroSerializer<>();
     playEventSerializer.configure(serdeConfig, false);
-
+  
     final SpecificAvroSerializer<Song> songSerializer = new SpecificAvroSerializer<>();
     songSerializer.configure(serdeConfig, false);
-
+  
     final KafkaProducer<String, PlayEvent> playEventProducer = new KafkaProducer<>(props,
                                                                                    Serdes.String() .serializer(),
                                                                                    playEventSerializer);
-
+  
     final KafkaProducer<Long, Song> songProducer = new KafkaProducer<>(props,
                                                                        new LongSerializer(),
                                                                        songSerializer);
-
-    final List<Song> songs = Arrays.asList(new Song(1L,
-                                                    "Fresh Fruit For Rotting Vegetables",
-                                                    "Dead Kennedys",
-                                                    "Chemical Warfare",
-                                                    "Punk"),
-                                           new Song(2L,
-                                                    "We Are the League",
-                                                    "Anti-Nowhere League",
-                                                    "Animal",
-                                                    "Punk"),
-                                           new Song(3L,
-                                                    "Live In A Dive",
-                                                    "Subhumans",
-                                                    "All Gone Dead",
-                                                    "Punk"),
-                                           new Song(4L,
-                                                    "PSI",
-                                                    "Wheres The Pope?",
-                                                    "Fear Of God",
-                                                    "Punk"),
-                                           new Song(5L,
-                                                    "Totally Exploited",
-                                                    "The Exploited",
-                                                    "Punks Not Dead",
-                                                    "Punk"),
-                                           new Song(6L,
-                                                    "The Audacity Of Hype",
-                                                    "Jello Biafra And The Guantanamo School Of "
-                                                    + "Medicine",
-                                                    "Three Strikes",
-                                                    "Punk"),
-                                           new Song(7L,
-                                                    "Licensed to Ill",
-                                                    "The Beastie Boys",
-                                                    "Fight For Your Right",
-                                                    "Hip Hop"),
-                                           new Song(8L,
-                                                    "De La Soul Is Dead",
-                                                    "De La Soul",
-                                                    "Oodles Of O's",
-                                                    "Hip Hop"),
-                                           new Song(9L,
-                                                    "Straight Outta Compton",
-                                                    "N.W.A",
-                                                    "Gangsta Gangsta",
-                                                    "Hip Hop"),
-                                           new Song(10L,
-                                                    "Fear Of A Black Planet",
-                                                    "Public Enemy",
-                                                    "911 Is A Joke",
-                                                    "Hip Hop"),
-                                           new Song(11L,
-                                                    "Curtain Call - The Hits",
-                                                    "Eminem",
-                                                    "Fack",
-                                                    "Hip Hop"),
-                                           new Song(12L,
-                                                    "The Calling",
-                                                    "Hilltop Hoods",
-                                                    "The Calling",
-                                                    "Hip Hop")
-
-                                           );
-
+  
     songs.forEach(song -> songProducer.send(
         new ProducerRecord<Long, Song>(KafkaMusicExample.SONG_FEED,
                                        song.getId(),
@@ -210,8 +188,29 @@ public class KafkaMusicExampleTest {
     sendPlayEvents(1, songs.get(11), playEventProducer);
 
     playEventProducer.close();
+  }
 
+  private void createStreams(final String host) throws Exception {
+    appServerPort = randomFreeLocalPort();
+    streams =
+        KafkaMusicExample.createChartsStreams(CLUSTER.bootstrapServers(),
+                                              CLUSTER.schemaRegistryUrl(),
+                                              appServerPort,
+                                              TestUtils.tempDirectory().getPath(),
+                                              host);
+    restProxy = KafkaMusicExample.startRestProxy(streams, new HostInfo(host, appServerPort));
+  }
 
+  @After
+  public void shutdown() throws Exception {
+    restProxy.stop();
+    streams.close();
+  }
+
+  @Test
+  public void shouldCreateChartsAndAccessThemViaInteractiveQueries() throws Exception {
+    final String host = "localhost";
+    createStreams(host);
     streams.start();
 
     // wait until the StreamsMetadata is available as this indicates that
@@ -219,8 +218,61 @@ public class KafkaMusicExampleTest {
     TestUtils.waitForCondition(() -> !StreamsMetadata.NOT_AVAILABLE.equals(streams.allMetadataForStore(KafkaMusicExample.TOP_FIVE_SONGS_STORE)),
                                MAX_WAIT_MS,
                                "StreamsMetadata should be available");
+    final String baseUrl = "http://" + host + ":" + appServerPort + "/kafka-music";
+    final Client client = ClientBuilder.newClient();
 
-    final String baseUrl = "http://localhost:" + appServerPort + "/kafka-music";
+    // Wait until the all-songs state store has some data in it
+    TestUtils.waitForCondition(() -> {
+      final ReadOnlyKeyValueStore<Long, Song>
+          songsStore;
+      try {
+        songsStore =
+            streams.store(KafkaMusicExample.ALL_SONGS, QueryableStoreTypes.<Long, Song>keyValueStore());
+        return songsStore.all().hasNext();
+      } catch (Exception e) {
+        return false;
+      }
+    }, MAX_WAIT_MS, KafkaMusicExample.ALL_SONGS + " should be non-empty");
+
+    final IntFunction<SongPlayCountBean> intFunction = index -> {
+      final Song song = songs.get(index);
+      return songCountPlayBean(song, 6L - (index % 6));
+    };
+
+    // Verify that the charts are as expected
+    verifyChart(baseUrl + "/charts/genre/punk",
+                client,
+                IntStream.range(0, 5).mapToObj(intFunction).collect(Collectors.toList()));
+
+    verifyChart(baseUrl + "/charts/genre/hip hop",
+                client,
+                IntStream.range(6, 11).mapToObj(intFunction).collect(Collectors.toList()));
+
+    verifyChart(baseUrl + "/charts/top-five",
+                client,
+                Arrays.asList(songCountPlayBean(songs.get(0), 6L),
+                              songCountPlayBean(songs.get(6), 6L),
+                              songCountPlayBean(songs.get(1), 5L),
+                              songCountPlayBean(songs.get(7), 5L),
+                              songCountPlayBean(songs.get(2), 4L)
+                              )
+                );
+
+  }
+
+  @Test
+  public void shouldDemonstrateInteractiveQueriesOnAnyValidHost() throws Exception {
+  final String host = "127.10.10.10";
+  createStreams(host);
+  streams.start();
+
+    // wait until the StreamsMetadata is available as this indicates that
+    // KafkaStreams initialization has occurred
+    TestUtils.waitForCondition(() -> !StreamsMetadata.NOT_AVAILABLE.equals(streams.allMetadataForStore(KafkaMusicExample.TOP_FIVE_SONGS_STORE)),
+                               MAX_WAIT_MS,
+                               "StreamsMetadata should be available");
+
+    final String baseUrl = "http://" + host + ":" + appServerPort + "/kafka-music";
     final Client client = ClientBuilder.newClient();
 
     // Wait until the all-songs state store has some data in it
@@ -299,7 +351,7 @@ public class KafkaMusicExampleTest {
     assertThat(chart, is(expectedChart));
   }
 
-  private void sendPlayEvents(final int count, final Song song,
+  private static void sendPlayEvents(final int count, final Song song,
                               final KafkaProducer<String, PlayEvent> producer) {
     for (int i = 0; i < count; i++) {
       producer.send(new ProducerRecord<>(

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
@@ -154,10 +154,10 @@ public class KafkaMusicExampleTest {
   private void createStreams(final String host) throws Exception {
     appServerPort = randomFreeLocalPort();
     streams = KafkaMusicExample.createChartsStreams(CLUSTER.bootstrapServers(),
-                                              CLUSTER.schemaRegistryUrl(),
-                                              appServerPort,
-                                              TestUtils.tempDirectory().getPath(),
-                                              host);
+                                                    CLUSTER.schemaRegistryUrl(),
+                                                    appServerPort,
+                                                    TestUtils.tempDirectory().getPath(),
+                                                    host);
     int count = 0;
     final int maxTries = 3;
     while (count <= maxTries) {

--- a/src/test/resources/song_source.csv
+++ b/src/test/resources/song_source.csv
@@ -1,0 +1,21 @@
+1,Fresh Fruit For Rotting Vegetables,Dead Kennedys,Chemical Warfare,Punk
+2,We Are the League,Anti-Nowhere League,Animal,Punk
+3,Live In A Dive,Subhumans,All Gone Dead,Punk
+4,PSI,Wheres The Pope?,Fear Of God,Punk
+5,Totally Exploited,The Exploited,Punks Not Dead,Punk
+6,The Audacity Of Hype,Jello Biafra And The Guantanamo School Of Medicine,Three Strikes,Punk
+7,Licensed to Ill,The Beastie Boys,Fight For Your Right,Hip Hop
+8,De La Soul Is Dead,De La Soul,Oodles Of O's,Hip Hop
+9,Straight Outta Compton,N.W.A,Gangsta Gangsta,Hip Hop
+10,Fear Of A Black Planet,Public Enemy,911 Is A Joke,Hip Hop
+11,Curtain Call - The Hits,Eminem,Fack,Hip Hop
+12,21,Adele,Rolling in the Deep,Pop
+13,In The Lonely Hour,Sam Smith,Stay With Me,Pop
+14,The Calling,Hilltop Hoods,The Calling,Hip Hop
+15,x,Ed Sheeran,Thinking Out Loud,Pop
+16,V,Maroon 5,Sugar,Pop
+17,This Is What The Truth Feels Like,Gwen Stefani,Red Flag,Pop
+18,This Is Acting,Sia,Alive,Pop
+19,24K Magic,Bruno Mars,That's What I Like,Pop
+20,Black Sunday,Cypress Hill,Insane in the Brain,Hip Hop
+21,Aquemini,Outkast,Aquemini,Hip Hop


### PR DESCRIPTION
Currently, any string provided as the APPLICATION_HOST will start the REST Service on localhost (0.0.0.0).

This fix will enhance the functionality by- 
- Validating the HOST and raising the exception for any invalid/ unreachable/ unavailable host.
- Starts the REST service on the provided host and port (If valid). 

Issue link: https://github.com/confluentinc/kafka-streams-examples/issues/127
