### PR TITLE
Fix flaky interactive query tests

### DIFF
--- a/src/test/java/io/confluent/examples/streams/ExampleTestUtils.java
+++ b/src/test/java/io/confluent/examples/streams/ExampleTestUtils.java
@@ -15,6 +15,11 @@ public class ExampleTestUtils {
 
     public static String randomValidHost() {
         Random r = new Random();
-        return "127." + r.nextInt(10) + "." + r.nextInt(10) + "." + r.nextInt(256);
+
+        if (r.nextFloat() < 0.1) {
+            return "localhost";
+        } else {
+            return "127." + r.nextInt(10) + "." + r.nextInt(10) + "." + r.nextInt(256);
+        }
     }
 }

--- a/src/test/java/io/confluent/examples/streams/ExampleTestUtils.java
+++ b/src/test/java/io/confluent/examples/streams/ExampleTestUtils.java
@@ -1,0 +1,20 @@
+package io.confluent.examples.streams;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Random;
+
+public class ExampleTestUtils {
+
+    public static int randomFreeLocalPort() throws IOException {
+        ServerSocket s = new ServerSocket(0);
+        int port = s.getLocalPort();
+        s.close();
+        return port;
+    }
+
+    public static String randomHost() {
+        Random r = new Random();
+        return r.nextInt(256) + "." + r.nextInt(256) + "." + r.nextInt(256) + "." + r.nextInt(256);
+    }
+}

--- a/src/test/java/io/confluent/examples/streams/ExampleTestUtils.java
+++ b/src/test/java/io/confluent/examples/streams/ExampleTestUtils.java
@@ -7,14 +7,14 @@ import java.util.Random;
 public class ExampleTestUtils {
 
     public static int randomFreeLocalPort() throws IOException {
-        ServerSocket s = new ServerSocket(0);
-        int port = s.getLocalPort();
+        final ServerSocket s = new ServerSocket(0);
+        final int port = s.getLocalPort();
         s.close();
         return port;
     }
 
     public static String randomValidHost() {
-        Random r = new Random();
+        final Random r = new Random();
 
         if (r.nextFloat() < 0.1) {
             return "localhost";

--- a/src/test/java/io/confluent/examples/streams/ExampleTestUtils.java
+++ b/src/test/java/io/confluent/examples/streams/ExampleTestUtils.java
@@ -13,8 +13,8 @@ public class ExampleTestUtils {
         return port;
     }
 
-    public static String randomHost() {
+    public static String randomValidHost() {
         Random r = new Random();
-        return r.nextInt(256) + "." + r.nextInt(256) + "." + r.nextInt(256) + "." + r.nextInt(256);
+        return "127." + r.nextInt(10) + "." + r.nextInt(10) + "." + r.nextInt(256);
     }
 }

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
@@ -126,7 +126,7 @@ public class WordCountInteractiveQueriesExampleTest {
 
   @Test
   public void shouldDemonstrateInteractiveQueries() throws Exception {
-    final String host = "127.10.10.10";//ExampleTestUtils.randomHost();
+    final String host = ExampleTestUtils.randomHost();
     final int port = ExampleTestUtils.randomFreeLocalPort();
     final String baseUrl = "http://" + host + ":" + port + "/state";
 

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
@@ -17,6 +17,7 @@ package io.confluent.examples.streams.interactivequeries;
 
 import com.google.common.collect.Sets;
 import io.confluent.examples.streams.IntegrationTestUtils;
+import io.confluent.examples.streams.ExampleTestUtils;
 import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -42,7 +43,6 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -124,17 +124,10 @@ public class WordCountInteractiveQueriesExampleTest {
     }
   }
 
-  public static int randomFreeLocalPort() throws IOException {
-    ServerSocket s = new ServerSocket(0);
-    int port = s.getLocalPort();
-    s.close();
-    return port;
-  }
-
   @Test
   public void shouldDemonstrateInteractiveQueries() throws Exception {
-    final int port = randomFreeLocalPort();
-    final String host = "localhost";
+    final String host = "127.10.10.10";//ExampleTestUtils.randomHost();
+    final int port = ExampleTestUtils.randomFreeLocalPort();
     final String baseUrl = "http://" + host + ":" + port + "/state";
 
     kafkaStreams = WordCountInteractiveQueriesExample.createStreams(
@@ -147,12 +140,14 @@ public class WordCountInteractiveQueriesExampleTest {
         }
     });
     kafkaStreams.start();
-  
+
+    System.out.println("Streams application service starts at " + baseUrl);
+
+    assertTrue("streams failed to start within timeout", startupLatch.await(30, TimeUnit.SECONDS));
+
     bindHostAndStartRestProxy(port, host);
   
     if (proxy != null) {
-      assertTrue("streams failed to start within timeout", startupLatch.await(30, TimeUnit.SECONDS));
-    
       final Client client = ClientBuilder.newClient();
     
       // Create a request to fetch all instances of HostStoreInfo
@@ -250,9 +245,9 @@ public class WordCountInteractiveQueriesExampleTest {
     }
   }
   
-  private void bindHostAndStartRestProxy(int port, String host) {
+  private void bindHostAndStartRestProxy(int port, String host) throws InterruptedException {
     int count = 0;
-    int maxTries = 3;
+    int maxTries = 10;
     while (count <= maxTries) {
       try {
         // Starts the Rest Service on the provided host:port
@@ -260,134 +255,16 @@ public class WordCountInteractiveQueriesExampleTest {
       } catch (Exception ex) {
         log.error("Could not start Rest Service due to: " + ex.toString());
       }
+
+      Thread.sleep(1000);
+
       count++;
-    }
-  }
-  
-  @Test
-  public void shouldStartRestApiOnAnyValidHost() throws Exception {
-    final int port = randomFreeLocalPort();
-    
-    // Any valid host or IP.
-    final String host = "127.10.10.10";
-    final String baseUrl = "http://" + host + ":" + port + "/state";
-
-    kafkaStreams = WordCountInteractiveQueriesExample.createStreams(
-        createStreamConfig(CLUSTER.bootstrapServers(), port, "one", host));
-
-    final CountDownLatch startupLatch = new CountDownLatch(1);
-    kafkaStreams.setStateListener((newState, oldState) -> {
-        if (newState == KafkaStreams.State.RUNNING && oldState == KafkaStreams.State.REBALANCING) {
-          startupLatch.countDown();
-        }
-    });
-    kafkaStreams.start();
-    
-    bindHostAndStartRestProxy(port, host);
-  
-    if (proxy != null) {
-      assertTrue("streams failed to start within timeout", startupLatch.await(30, TimeUnit.SECONDS));
-    
-      final Client client = ClientBuilder.newClient();
-    
-      // Create a request to fetch all instances of HostStoreInfo
-      final Invocation.Builder allInstancesRequest = client.target(baseUrl + "/instances")
-              .request(MediaType.APPLICATION_JSON_TYPE);
-      final List<HostStoreInfo> hostStoreInfo = fetchHostInfo(allInstancesRequest);
-    
-      assertThat(hostStoreInfo, hasItem(
-              new HostStoreInfo("127.10.10.10", port, Sets.newHashSet("word-count", "windowed-word-count"))
-      ));
-    
-      // Create a request to fetch all instances with word-count
-      final Invocation.Builder wordCountInstancesRequest = client.target(baseUrl + "/instances/word-count")
-              .request(MediaType.APPLICATION_JSON_TYPE);
-      final List<HostStoreInfo>
-              wordCountInstances = fetchHostInfo(wordCountInstancesRequest);
-    
-      assertThat(wordCountInstances, hasItem(
-              new HostStoreInfo("127.10.10.10", port, Sets.newHashSet("word-count", "windowed-word-count"))
-      ));
-    
-      Properties consumerConfig = new Properties();
-      consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-      consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-      consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-      consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "wait-for-output-consumer-new-host");
-      consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-      IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerConfig, WORD_COUNT_OUTPUT, inputValues.size());
-      IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerConfig, WINDOWED_WORD_COUNT_OUTPUT, inputValues.size());
-    
-      // Fetch all key-value pairs from the word-count store
-      final Invocation.Builder
-              allRequest =
-              client.target(baseUrl + "/keyvalues/word-count/all")
-                      .request(MediaType.APPLICATION_JSON_TYPE);
-    
-      final List<KeyValueBean>
-              allValues =
-              Arrays.asList(new KeyValueBean("all", 1L),
-                      new KeyValueBean("hello", 2L),
-                      new KeyValueBean("kafka", 2L),
-                      new KeyValueBean("lead", 1L),
-                      new KeyValueBean("streams", 3L),
-                      new KeyValueBean("to", 1L),
-                      new KeyValueBean("world", 3L));
-      final List<KeyValueBean>
-              all = fetchRangeOfValues(allRequest,
-              allValues);
-      assertThat(all, equalTo(allValues));
-    
-      // Fetch a range of key-value pairs from the word-count store
-      final List<KeyValueBean> expectedRange = Arrays.asList(
-              new KeyValueBean("all", 1L),
-              new KeyValueBean("hello", 2L),
-              new KeyValueBean("kafka", 2L));
-    
-      final Invocation.Builder
-              request =
-              client.target(baseUrl + "/keyvalues/word-count/range/all/kafka")
-                      .request(MediaType.APPLICATION_JSON_TYPE);
-      final List<KeyValueBean>
-              range = fetchRangeOfValues(request, expectedRange);
-    
-      assertThat(range, equalTo(expectedRange));
-    
-      // Find the instance of the Kafka Streams application that would have the key hello
-      final HostStoreInfo
-              hostWithHelloKey =
-              client.target(baseUrl + "/instance/word-count/hello")
-                      .request(MediaType.APPLICATION_JSON_TYPE).get(HostStoreInfo.class);
-    
-      // Fetch the value for the key hello from the instance.
-      final KeyValueBean result = client.target("http://" + hostWithHelloKey.getHost() +
-              ":" + hostWithHelloKey.getPort() +
-              "/state/keyvalue/word-count/hello")
-              .request(MediaType.APPLICATION_JSON_TYPE).get(KeyValueBean.class);
-    
-      assertThat(result, equalTo(new KeyValueBean("hello", 2L)));
-    
-      // fetch windowed values for a key
-      final List<KeyValueBean>
-              windowedResult =
-              client.target(baseUrl + "/windowed/windowed-word-count/streams/0/" + System
-                      .currentTimeMillis())
-                      .request(MediaType.APPLICATION_JSON_TYPE)
-                    
-                      .get(new GenericType<List<KeyValueBean>>() {
-                      });
-      assertThat(windowedResult.size(), equalTo(1));
-      final KeyValueBean keyValueBean = windowedResult.get(0);
-      assertTrue(keyValueBean.getKey().startsWith("streams"));
-      assertThat(keyValueBean.getValue(), equalTo(3L));
-    } else {
-      fail("Should fail demonstrating InteractiveQueries on any valid host as the Rest Service failed to start.");
     }
   }
   
   @Test(expected = Exception.class)
   public void shouldThrowExceptionForInvalidHost() throws Exception {
-    final int port = randomFreeLocalPort();
+    final int port = ExampleTestUtils.randomFreeLocalPort();
     final String host = "someInvalidHost";
     
     kafkaStreams = WordCountInteractiveQueriesExample.createStreams(
@@ -406,7 +283,7 @@ public class WordCountInteractiveQueriesExampleTest {
   
   @Test
   public void shouldThrowBindExceptionForUnavailablePort() throws Exception {
-    final int port = randomFreeLocalPort();
+    final int port = ExampleTestUtils.randomFreeLocalPort();
     final String host = "localhost";
     
     kafkaStreams = WordCountInteractiveQueriesExample.createStreams(

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
@@ -156,7 +156,7 @@ public class WordCountInteractiveQueriesExampleTest {
       final List<HostStoreInfo> hostStoreInfo = fetchHostInfo(allInstancesRequest);
     
       assertThat(hostStoreInfo, hasItem(
-              new HostStoreInfo("localhost", port, Sets.newHashSet("word-count", "windowed-word-count"))
+              new HostStoreInfo(host, port, Sets.newHashSet("word-count", "windowed-word-count"))
       ));
     
       // Create a request to fetch all instances with word-count
@@ -166,7 +166,7 @@ public class WordCountInteractiveQueriesExampleTest {
               wordCountInstances = fetchHostInfo(wordCountInstancesRequest);
     
       assertThat(wordCountInstances, hasItem(
-              new HostStoreInfo("localhost", port, Sets.newHashSet("word-count", "windowed-word-count"))
+              new HostStoreInfo(host, port, Sets.newHashSet("word-count", "windowed-word-count"))
       ));
     
       Properties consumerConfig = new Properties();

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
@@ -126,7 +126,7 @@ public class WordCountInteractiveQueriesExampleTest {
 
   @Test
   public void shouldDemonstrateInteractiveQueries() throws Exception {
-    final String host = ExampleTestUtils.randomHost();
+    final String host = ExampleTestUtils.randomValidHost();
     final int port = ExampleTestUtils.randomFreeLocalPort();
     final String baseUrl = "http://" + host + ":" + port + "/state";
 

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
@@ -325,8 +325,7 @@ public class WordCountInteractiveQueriesExampleTest {
   }
 
   private List<KeyValueBean> fetchRangeOfValues(final Invocation.Builder request,
-                                                final List<KeyValueBean>
-                                                    expectedResults) {
+                                                final List<KeyValueBean> expectedResults) {
     List<KeyValueBean> results = new ArrayList<>();
     final long timeout = System.currentTimeMillis() + 10000L;
     while (!results.containsAll(expectedResults) && System.currentTimeMillis() < timeout) {

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
@@ -141,8 +141,6 @@ public class WordCountInteractiveQueriesExampleTest {
     });
     kafkaStreams.start();
 
-    System.out.println("Streams application service starts at " + baseUrl);
-
     assertTrue("streams failed to start within timeout", startupLatch.await(30, TimeUnit.SECONDS));
 
     bindHostAndStartRestProxy(port, host);

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
@@ -18,6 +18,7 @@ package io.confluent.examples.streams.interactivequeries.kafkamusic;
 import io.confluent.examples.streams.avro.PlayEvent;
 import io.confluent.examples.streams.avro.Song;
 import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
+import io.confluent.examples.streams.ExampleTestUtils;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerializer;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -56,11 +57,8 @@ import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static io.confluent.examples.streams.interactivequeries.WordCountInteractiveQueriesExampleTest.randomFreeLocalPort;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static junit.framework.TestCase.fail;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * End-to-end integration test for {@link KafkaMusicExample}. Demonstrates
@@ -76,7 +74,7 @@ public class KafkaMusicExampleTest {
   private int appServerPort;
   private static final List<Song> songs = new ArrayList<>();
   private static final Logger log = LoggerFactory.getLogger(KafkaMusicExampleTest.class);
-  
+
   @BeforeClass
   public static void createTopicsAndProduceDataToInputTopics() throws Exception {
     CLUSTER.createTopic(KafkaMusicExample.PLAY_EVENTS);
@@ -151,9 +149,8 @@ public class KafkaMusicExampleTest {
     playEventProducer.close();
   }
 
-
   private void createStreams(final String host) throws Exception {
-    appServerPort = randomFreeLocalPort();
+    appServerPort = ExampleTestUtils.randomFreeLocalPort();
     streams = KafkaMusicExample.createChartsStreams(CLUSTER.bootstrapServers(),
         CLUSTER.schemaRegistryUrl(),
         appServerPort,
@@ -184,7 +181,7 @@ public class KafkaMusicExampleTest {
 
   @Test
   public void shouldCreateChartsAndAccessThemViaInteractiveQueries() throws Exception {
-    final String host = "localhost";
+    final String host = "127.10.10.10";//ExampleTestUtils.randomHost();
     createStreams(host);
     streams.start();
 
@@ -239,64 +236,6 @@ public class KafkaMusicExampleTest {
     }
   }
 
-  @Test
-  public void shouldDemonstrateInteractiveQueriesOnAnyValidHost() throws Exception {
-    final String host = "127.10.10.10";
-    createStreams(host);
-    streams.start();
-  
-    if (restProxy != null) {
-      // wait until the StreamsMetadata is available as this indicates that
-      // KafkaStreams initialization has occurred
-      TestUtils.waitForCondition(() -> !StreamsMetadata.NOT_AVAILABLE.equals(streams.allMetadataForStore(KafkaMusicExample.TOP_FIVE_SONGS_STORE)),
-                                 MAX_WAIT_MS,
-                                 "StreamsMetadata should be available");
-  
-      final String baseUrl = "http://" + host + ":" + appServerPort + "/kafka-music";
-      final Client client = ClientBuilder.newClient();
-  
-      // Wait until the all-songs state store has some data in it
-      TestUtils.waitForCondition(() -> {
-        final ReadOnlyKeyValueStore<Long, Song>
-            songsStore;
-        try {
-          songsStore =
-              streams.store(KafkaMusicExample.ALL_SONGS, QueryableStoreTypes.keyValueStore());
-          return songsStore.all().hasNext();
-        } catch (Exception e) {
-          return false;
-        }
-      }, MAX_WAIT_MS, KafkaMusicExample.ALL_SONGS + " should be non-empty");
-  
-      final IntFunction<SongPlayCountBean> intFunction = index -> {
-        final Song song = songs.get(index);
-        return songCountPlayBean(song, 6L - (index % 6));
-      };
-  
-      // Verify that the charts are as expected
-      verifyChart(baseUrl + "/charts/genre/punk",
-                  client,
-                  IntStream.range(0, 5).mapToObj(intFunction).collect(Collectors.toList()));
-  
-      verifyChart(baseUrl + "/charts/genre/hip hop",
-                  client,
-                  IntStream.range(6, 11).mapToObj(intFunction).collect(Collectors.toList()));
-  
-      verifyChart(baseUrl + "/charts/top-five",
-                  client,
-                  Arrays.asList(songCountPlayBean(songs.get(0), 6L),
-                                songCountPlayBean(songs.get(6), 6L),
-                                songCountPlayBean(songs.get(1), 5L),
-                                songCountPlayBean(songs.get(7), 5L),
-                                songCountPlayBean(songs.get(2), 4L)
-                                )
-                  );
-  
-    } else {
-      fail("Should fail demonstrating InteractiveQueries on any valid host as the Rest Service failed to start.");
-    }
-  }
-
   private SongPlayCountBean songCountPlayBean(final Song song, final long plays) {
     return new SongPlayCountBean(song.getArtist(),
                                  song.getAlbum(),
@@ -314,24 +253,14 @@ public class KafkaMusicExampleTest {
     // Wait until we have 5 items available in the chart
     TestUtils.waitForCondition(() -> {
       try {
-        final List<SongPlayCountBean>
-            chart =
-            genreChartRequest.get(new GenericType<List<SongPlayCountBean>>() {
-            });
-        return chart.size() == 5;
+        final List<SongPlayCountBean> chart =
+            genreChartRequest.get(new GenericType<List<SongPlayCountBean>>() {});
+        return chart.equals(expectedChart);
       } catch (Exception e) {
         return false;
       }
 
     }, MAX_WAIT_MS, "chart should have 5 items");
-
-
-    final List<SongPlayCountBean>
-        chart =
-        genreChartRequest.get(new GenericType<List<SongPlayCountBean>>() {
-        });
-
-    assertThat(chart, is(expectedChart));
   }
 
   private static void sendPlayEvents(final int count,

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
@@ -250,7 +250,6 @@ public class KafkaMusicExampleTest {
     final Invocation.Builder genreChartRequest = client.target(url)
         .request(MediaType.APPLICATION_JSON_TYPE);
 
-    // Wait until we have 5 items available in the chart
     TestUtils.waitForCondition(() -> {
       try {
         final List<SongPlayCountBean> chart =
@@ -260,7 +259,7 @@ public class KafkaMusicExampleTest {
         return false;
       }
 
-    }, MAX_WAIT_MS, "chart should have 5 items");
+    }, MAX_WAIT_MS, "Returned chart should equal to the expected items");
   }
 
   private static void sendPlayEvents(final int count,

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
@@ -181,7 +181,7 @@ public class KafkaMusicExampleTest {
 
   @Test
   public void shouldCreateChartsAndAccessThemViaInteractiveQueries() throws Exception {
-    final String host = "127.10.10.10";//ExampleTestUtils.randomHost();
+    final String host = ExampleTestUtils.randomHost();
     createStreams(host);
     streams.start();
 

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
@@ -181,7 +181,7 @@ public class KafkaMusicExampleTest {
 
   @Test
   public void shouldCreateChartsAndAccessThemViaInteractiveQueries() throws Exception {
-    final String host = ExampleTestUtils.randomHost();
+    final String host = ExampleTestUtils.randomValidHost();
     createStreams(host);
     streams.start();
 

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=DEBUG, stdout
+log4j.rootLogger=WARN, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
1. The actual fix of the flakiness: we need to include the comparison of the expected result with the actual result into the `waitForCondition` as well to allow retries. Before that we only wait for the query to return the expected number of entries, but not all entries have been updated to date.

2. Cleanup: on the two interactivequeries tests, we have duplicated tests one for `host = localhost` and one for `host = 127.10.10.10` just to test that any valid host should work. I've consolidated them to generate a random valid host each time.