### PR TITLE
KSTREAMS-1712: Add option for configuring Producers, Consumers with interceptors

### DIFF
--- a/src/main/java/io/confluent/examples/streams/WikipediaFeedAvroExample.java
+++ b/src/main/java/io/confluent/examples/streams/WikipediaFeedAvroExample.java
@@ -29,7 +29,6 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
-import org.apache.kafka.streams.kstream.Predicate;
 import org.apache.kafka.streams.kstream.Produced;
 
 import java.util.Properties;
@@ -133,7 +132,7 @@ public class WikipediaFeedAvroExample {
     // If Confluent monitoring interceptors are on the classpath,
     // then the producer and consumer interceptors are added to the
     // streams application.
-    MonitoringInterceptorUtils.maybeConfigureInterceptors(streamsConfiguration);
+    MonitoringInterceptorUtils.maybeConfigureInterceptorsStreams(streamsConfiguration);
 
     final Serde<String> stringSerde = Serdes.String();
     final Serde<Long> longSerde = Serdes.Long();

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesDriver.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesDriver.java
@@ -15,6 +15,7 @@
  */
 package io.confluent.examples.streams.interactivequeries;
 
+import io.confluent.examples.streams.utils.MonitoringInterceptorUtils;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -66,6 +67,8 @@ public class WordCountInteractiveQueriesDriver {
     producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
     producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+    MonitoringInterceptorUtils.maybeConfigureInterceptorsProducer(producerConfig);
 
     final KafkaProducer<String, String>
         producer =

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesDriver.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesDriver.java
@@ -15,16 +15,14 @@
  */
 package io.confluent.examples.streams.interactivequeries;
 
-import io.confluent.examples.streams.utils.MonitoringInterceptorUtils;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.serialization.StringSerializer;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
 
 
 /**

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesDriver.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesDriver.java
@@ -15,15 +15,15 @@
  */
 package io.confluent.examples.streams.interactivequeries;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Properties;
-import java.util.Random;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
 
 /**
  * This is a sample driver for the {@link WordCountInteractiveQueriesExample}.

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesDriver.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesDriver.java
@@ -68,8 +68,6 @@ public class WordCountInteractiveQueriesDriver {
     producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
 
-    MonitoringInterceptorUtils.maybeConfigureInterceptorsProducer(producerConfig);
-
     final KafkaProducer<String, String>
         producer =
         new KafkaProducer<>(producerConfig, new StringSerializer(), new StringSerializer());

--- a/src/main/java/io/confluent/examples/streams/utils/MonitoringInterceptorUtils.java
+++ b/src/main/java/io/confluent/examples/streams/utils/MonitoringInterceptorUtils.java
@@ -5,6 +5,8 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.streams.StreamsConfig;
 
 import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility helper class that will enable Monitoring Interceptors when
@@ -18,7 +20,7 @@ public class MonitoringInterceptorUtils {
 
     private static final String CONSUMER_INTERCEPTOR = "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor";
     private static final String PRODUCER_INTERCEPTOR = "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor";
-
+    private static final Logger LOG = LoggerFactory.getLogger(MonitoringInterceptorUtils.class);
 
     private MonitoringInterceptorUtils() {
     }
@@ -58,7 +60,7 @@ public class MonitoringInterceptorUtils {
             Class.forName(className);
         } catch (final ClassNotFoundException e) {
             final String interceptorTypeShortName = className.substring(className.lastIndexOf('.'));
-            System.out.println(String.format("%s not found, skipping", interceptorTypeShortName));
+            LOG.info("{} not found, skipping", interceptorTypeShortName);
             hasInterceptor = false;
         }
         return hasInterceptor;

--- a/src/main/java/io/confluent/examples/streams/utils/MonitoringInterceptorUtils.java
+++ b/src/main/java/io/confluent/examples/streams/utils/MonitoringInterceptorUtils.java
@@ -23,22 +23,45 @@ public class MonitoringInterceptorUtils {
     private MonitoringInterceptorUtils() {
     }
 
-    public static void maybeConfigureInterceptors(final Properties streamsConfig) {
-        try {
-            Class.forName(PRODUCER_INTERCEPTOR);
-        } catch (final ClassNotFoundException e) {
-            System.out.println("Monitoring Producer Interceptors not found, skipping");
-            return;
+    public static void maybeConfigureInterceptorsStreams(final Properties streamsConfig) {
+        if (hasMonitoringConsumerInterceptor() && hasMonitoringProducerInterceptor()) {
+            streamsConfig.put(StreamsConfig.producerPrefix(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG), PRODUCER_INTERCEPTOR);
+            streamsConfig.put(StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG), CONSUMER_INTERCEPTOR);
         }
+    }
 
-        try {
-            Class.forName(CONSUMER_INTERCEPTOR);
-        } catch (final ClassNotFoundException e) {
-            System.out.println("Monitoring Consumer Interceptors not found, skipping");
-            return;
+    public static void maybeConfigureInterceptorsProducer(final Properties producerConfig) {
+        if (hasMonitoringProducerInterceptor()) {
+            producerConfig.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, PRODUCER_INTERCEPTOR);
         }
-        streamsConfig.put(StreamsConfig.producerPrefix(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG), PRODUCER_INTERCEPTOR);
-        streamsConfig.put(StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG), CONSUMER_INTERCEPTOR);
+    }
+
+    public static void maybeConfigureInterceptorsConsumer(final Properties consumerConfig) {
+         if(hasMonitoringConsumerInterceptor()) {
+             consumerConfig.put(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, CONSUMER_INTERCEPTOR);
+         }
+    }
+
+
+
+    private static boolean hasMonitoringProducerInterceptor() {
+        return hasMonitoringInterceptor(PRODUCER_INTERCEPTOR);
+    }
+
+    private static boolean hasMonitoringConsumerInterceptor() {
+        return hasMonitoringInterceptor(CONSUMER_INTERCEPTOR);
+    }
+
+    private static boolean hasMonitoringInterceptor(final String className) {
+        boolean hasInterceptor = true;
+        try {
+            Class.forName(className);
+        } catch (final ClassNotFoundException e) {
+            final String interceptorTypeShortName = className.substring(className.lastIndexOf('.'));
+            System.out.println(String.format("%s not found, skipping", interceptorTypeShortName));
+            hasInterceptor = false;
+        }
+        return hasInterceptor;
     }
 
 }

--- a/src/test/java/io/confluent/examples/streams/GlobalKTablesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/GlobalKTablesExampleTest.java
@@ -19,6 +19,7 @@ import io.confluent.examples.streams.avro.EnrichedOrder;
 import io.confluent.examples.streams.avro.Order;
 import io.confluent.examples.streams.avro.Product;
 import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
+import io.confluent.examples.streams.utils.MonitoringInterceptorUtils;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
@@ -117,6 +118,8 @@ public class GlobalKTablesExampleTest {
     consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class);
     consumerProps.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, CLUSTER.schemaRegistryUrl());
     consumerProps.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, true);
+
+    MonitoringInterceptorUtils.maybeConfigureInterceptorsConsumer(consumerProps);
 
     // receive the enriched orders
     final List<EnrichedOrder>

--- a/src/test/java/io/confluent/examples/streams/TopArticlesLambdaExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/TopArticlesLambdaExampleTest.java
@@ -16,6 +16,7 @@
 package io.confluent.examples.streams;
 
 import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
+import io.confluent.examples.streams.utils.MonitoringInterceptorUtils;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
@@ -87,6 +88,9 @@ public class TopArticlesLambdaExampleTest {
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
               io.confluent.kafka.serializers.KafkaAvroSerializer.class);
     props.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, CLUSTER.schemaRegistryUrl());
+
+    MonitoringInterceptorUtils.maybeConfigureInterceptorsProducer(props);
+
     final KafkaProducer<String, GenericRecord> producer = new KafkaProducer<>(props);
 
     final GenericRecordBuilder pageViewBuilder =
@@ -115,6 +119,9 @@ public class TopArticlesLambdaExampleTest {
     consumerProperties.put(ConsumerConfig.GROUP_ID_CONFIG, "top-articles-consumer");
     consumerProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     final Deserializer<Windowed<String>> windowedDeserializer = WindowedSerdes.timeWindowedSerdeFrom(String.class).deserializer();
+
+    MonitoringInterceptorUtils.maybeConfigureInterceptorsConsumer(consumerProperties);
+
     final KafkaConsumer<Windowed<String>, String> consumer = new KafkaConsumer<>(consumerProperties,
                                                                                  windowedDeserializer,
                                                                                  Serdes.String().deserializer());


### PR DESCRIPTION
Refactored `MonitoringInterceptorUtils` to be able to configure individual producers and consumers in addition to configuring a streams application with Confluent Monitoring interceptors.

For testing, I picked two tests and added configuration for monitoring interceptors and confirmed configuration and usage via logs.