### PR TITLE
Use scala-library 2.12.7 and replace assert4J with scalatest assert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <java.version>1.8</java.version>
         <licenses.version>5.2.0-SNAPSHOT</licenses.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scala.version>${kafka.scala.version}.8</scala.version>
+        <scala.version>${kafka.scala.version}.7</scala.version>
         <scalatest.version>2.2.6</scalatest.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <licenses.version>5.2.0-SNAPSHOT</licenses.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala.version>${kafka.scala.version}.7</scala.version>
-        <scalatest.version>2.2.6</scalatest.version>
+        <scalatest.version>3.0.5</scalatest.version>
     </properties>
 
     <dependencies>

--- a/src/test/scala/io/confluent/examples/streams/GenericAvroScalaIntegrationTest.scala
+++ b/src/test/scala/io/confluent/examples/streams/GenericAvroScalaIntegrationTest.scala
@@ -27,7 +27,6 @@ import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization._
 import org.apache.kafka.streams.scala.StreamsBuilder
 import org.apache.kafka.streams.{KafkaStreams, StreamsConfig}
-import org.assertj.core.api.Assertions.assertThat
 import org.junit._
 import org.scalatest.junit.AssertionsForJUnit
 
@@ -126,7 +125,7 @@ class GenericAvroScalaIntegrationTest extends AssertionsForJUnit {
     val actualValues: java.util.List[GenericRecord] =
       IntegrationTestUtils.waitUntilMinValuesRecordsReceived(consumerConfig, outputTopic, inputValues.size)
     streams.close()
-    assertThat(actualValues).containsExactlyElementsOf(inputValues.asJava)
+    assert(actualValues === inputValues.asJava)
   }
 
 }

--- a/src/test/scala/io/confluent/examples/streams/ProbabilisticCountingScalaIntegrationTest.scala
+++ b/src/test/scala/io/confluent/examples/streams/ProbabilisticCountingScalaIntegrationTest.scala
@@ -28,7 +28,6 @@ import org.apache.kafka.streams.scala.StreamsBuilder
 import org.apache.kafka.streams.scala.kstream.KStream
 import org.apache.kafka.streams.{KafkaStreams, KeyValue, StreamsConfig}
 import org.apache.kafka.test.TestUtils
-import org.assertj.core.api.Assertions.assertThat
 import org.junit._
 import org.scalatest.junit.AssertionsForJUnit
 
@@ -147,7 +146,7 @@ class ProbabilisticCountingScalaIntegrationTest extends AssertionsForJUnit {
     // Note: This example only processes a small amount of input data, for which the word counts
     // will actually be exact counts.  However, for large amounts of input data we would expect to
     // observe approximate counts (where the approximate counts would be >= true exact counts).
-    assertThat(actualWordCounts).containsExactlyElementsOf(expectedWordCounts.asJava)
+    assert(actualWordCounts === expectedWordCounts.asJava)
   }
 
   private def createCMSStoreBuilder(cmsStoreName: String): CMSStoreBuilder[String] = {

--- a/src/test/scala/io/confluent/examples/streams/SpecificAvroScalaIntegrationTest.scala
+++ b/src/test/scala/io/confluent/examples/streams/SpecificAvroScalaIntegrationTest.scala
@@ -26,7 +26,6 @@ import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization._
 import org.apache.kafka.streams.scala.StreamsBuilder
 import org.apache.kafka.streams.{KafkaStreams, StreamsConfig}
-import org.assertj.core.api.Assertions.assertThat
 import org.junit._
 import org.scalatest.junit.AssertionsForJUnit
 
@@ -119,7 +118,7 @@ class SpecificAvroScalaIntegrationTest extends AssertionsForJUnit {
     val actualValues: java.util.List[WikiFeed] =
       IntegrationTestUtils.waitUntilMinValuesRecordsReceived(consumerConfig, outputTopic, inputValues.size)
     streams.close()
-    assertThat(actualValues).containsExactlyElementsOf(inputValues.asJava)
+    assert(actualValues === inputValues.asJava)
   }
 
 }

--- a/src/test/scala/io/confluent/examples/streams/StreamToTableJoinScalaIntegrationTest.scala
+++ b/src/test/scala/io/confluent/examples/streams/StreamToTableJoinScalaIntegrationTest.scala
@@ -25,7 +25,6 @@ import org.apache.kafka.streams.scala.StreamsBuilder
 import org.apache.kafka.streams.scala.kstream.{KStream, KTable}
 import org.apache.kafka.streams.{KafkaStreams, KeyValue, StreamsConfig}
 import org.apache.kafka.test.TestUtils
-import org.assertj.core.api.Assertions.assertThat
 import org.junit._
 import org.scalatest.junit.AssertionsForJUnit
 
@@ -204,7 +203,7 @@ class StreamToTableJoinScalaIntegrationTest extends AssertionsForJUnit {
     val actualClicksPerRegion: java.util.List[KeyValue[String, Long]] = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerConfig,
       outputTopic, expectedClicksPerRegion.size)
     streams.close()
-    assertThat(actualClicksPerRegion).containsExactlyElementsOf(expectedClicksPerRegion.asJava)
+    assert(actualClicksPerRegion === expectedClicksPerRegion.asJava)
   }
 
 }

--- a/src/test/scala/io/confluent/examples/streams/WordCountScalaIntegrationTest.scala
+++ b/src/test/scala/io/confluent/examples/streams/WordCountScalaIntegrationTest.scala
@@ -25,7 +25,6 @@ import org.apache.kafka.streams.scala.StreamsBuilder
 import org.apache.kafka.streams.scala.kstream.{KStream, KTable}
 import org.apache.kafka.streams.{KafkaStreams, KeyValue, StreamsConfig}
 import org.apache.kafka.test.TestUtils
-import org.assertj.core.api.Assertions.assertThat
 import org.junit._
 import org.scalatest.junit.AssertionsForJUnit
 
@@ -139,7 +138,7 @@ class WordCountScalaIntegrationTest extends AssertionsForJUnit {
     val actualWordCounts: java.util.List[KeyValue[String, Long]] =
       IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerConfig, outputTopic, expectedWordCounts.size)
     streams.close()
-    assertThat(actualWordCounts).containsExactlyElementsOf(expectedWordCounts.asJava)
+    assert(actualWordCounts === expectedWordCounts.asJava)
   }
 
 }


### PR DESCRIPTION
We upgraded to Scala 2.12 in the common pom and we had to upgrade the
scalatest dependency to get a build for that Scala version.

The assert4J change is due to an overload ambiguity when using Scala 2.12.