### PR TITLE
MINOR: Update for jetty exception handling changes

### DIFF
--- a/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
+import org.hamcrest.core.IsInstanceOf;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -296,7 +297,7 @@ public class WordCountInteractiveQueriesExampleTest {
     kafkaStreams.start();
     proxy = WordCountInteractiveQueriesExample.startRestProxy(kafkaStreams, port, host);
     expectedEx.expect(Exception.class);
-    expectedEx.expectMessage("java.net.BindException: Address already in use");
+    expectedEx.expectCause(IsInstanceOf.instanceOf(java.net.BindException.class));
     // Binding to same port again will raise BindException.
     WordCountInteractiveQueriesExample.startRestProxy(kafkaStreams, port, host);
   }


### PR DESCRIPTION
This [commit on rest-utils **_master_**](https://github.com/confluentinc/rest-utils/commit/6547a7f2c25d97f0a5a961067adabacc06499116) upgraded Jetty versions.  The new version of Jetty includes this [commit](https://github.com/eclipse/jetty.project/commit/37a85152eb1a6a1aabbee226a660b07c700576aa#diff-1d979f16bca62b84b714de297a43aeecR342) catches the `BindException` and rethrows an `IOException`.

I've updated the test to check for the cause.  Pushing this PR to master as only as the updated Jetty version just pushed to `rest-utils` master.