### PR TITLE
Add custom join example where the table-side triggers a stream-table join, too

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ There are two kinds of examples:
 | WikipediaFeedSpecificAvro | Specific Avro | [Java 8+ example](src/main/java/io/confluent/examples/streams/WikipediaFeedAvroLambdaExample.java) | [Java 7+ example](src/main/java/io/confluent/examples/streams/WikipediaFeedAvroExample.java)
 | SecureKafkaStreams | Secure, encryption, client authentication | | [Java 7+ example](src/main/java/io/confluent/examples/streams/SecureKafkaStreamsExample.java)
 | StatesStoresDSL | State Stores, DSL | [Java 8+ example](src/test/java/io/confluent/examples/streams/StateStoresInTheDSLIntegrationTest.java)
+| CustomJoinWithTableTriggeringStreamTableJoin | Joins, Processor API, DSL, Transformers, Joins | [Java 8+ example](src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java)
 | WordCountInteractiveQueries | Interactive Queries, REST, RPC | [Java 8+ example](src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java)
 | KafkaMusic | Interactive Queries, State Stores, REST API | [Java 8+ example](src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExample.java)
 | PoisonPill | Corrupt input records | [Java 8+ example](src/test/java/io/confluent/examples/streams/HandlingCorruptedInputRecordsIntegrationTest.java)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ There are two kinds of examples:
 | WikipediaFeedSpecificAvro | Specific Avro | [Java 8+ example](src/main/java/io/confluent/examples/streams/WikipediaFeedAvroLambdaExample.java) | [Java 7+ example](src/main/java/io/confluent/examples/streams/WikipediaFeedAvroExample.java)
 | SecureKafkaStreams | Secure, encryption, client authentication | | [Java 7+ example](src/main/java/io/confluent/examples/streams/SecureKafkaStreamsExample.java)
 | StatesStoresDSL | State Stores, DSL | [Java 8+ example](src/test/java/io/confluent/examples/streams/StateStoresInTheDSLIntegrationTest.java)
-| CustomJoinWithTableTriggeringStreamTableJoin | Joins, Processor API, DSL, Transformers, Joins | [Java 8+ example](src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java)
+| CustomStreamTableJoin | Joins, Processor API, DSL, Transformers, Joins | [Java 8+ example](src/test/java/io/confluent/examples/streams/CustomStreamTableJoinIntegrationTest.java)
 | WordCountInteractiveQueries | Interactive Queries, REST, RPC | [Java 8+ example](src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java)
 | KafkaMusic | Interactive Queries, State Stores, REST API | [Java 8+ example](src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExample.java)
 | PoisonPill | Corrupt input records | [Java 8+ example](src/test/java/io/confluent/examples/streams/HandlingCorruptedInputRecordsIntegrationTest.java)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ There are two kinds of examples:
 | WikipediaFeedSpecificAvro | Specific Avro | [Java 8+ example](src/main/java/io/confluent/examples/streams/WikipediaFeedAvroLambdaExample.java) | [Java 7+ example](src/main/java/io/confluent/examples/streams/WikipediaFeedAvroExample.java)
 | SecureKafkaStreams | Secure, encryption, client authentication | | [Java 7+ example](src/main/java/io/confluent/examples/streams/SecureKafkaStreamsExample.java)
 | StatesStoresDSL | State Stores, DSL | [Java 8+ example](src/test/java/io/confluent/examples/streams/StateStoresInTheDSLIntegrationTest.java)
-| CustomStreamTableJoin | Joins, Processor API, DSL, Transformers, Joins | [Java 8+ example](src/test/java/io/confluent/examples/streams/CustomStreamTableJoinIntegrationTest.java)
+| CustomStreamTableJoin | How to implement custom join semantics with Processor API, DSL, Transformers | [Java 8+ example](src/test/java/io/confluent/examples/streams/CustomStreamTableJoinIntegrationTest.java)
 | WordCountInteractiveQueries | Interactive Queries, REST, RPC | [Java 8+ example](src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java)
 | KafkaMusic | Interactive Queries, State Stores, REST API | [Java 8+ example](src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExample.java)
 | PoisonPill | Corrupt input records | [Java 8+ example](src/test/java/io/confluent/examples/streams/HandlingCorruptedInputRecordsIntegrationTest.java)

--- a/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
@@ -72,6 +72,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * hopefully, see a matching record to arrive eventually.  However, if the per-key wait time has exceeded, then an
  * "incomplete" join output will be sent downstream.
  *
+ * The approach in this example shares state stores between a stream-side and a table-side transformer.  This is safe
+ * because, if shared, Kafka Streams will place the transformers as well as the state stores into the same stream task,
+ * in which all access is exclusive and single-threaded.  The state store on the table side is the normal store of a
+ * KTable (thus avoiding data duplication due to store usage), whereas the state store on the stream side is manually
+ * added and attached to the processing topology.  An alternative, more flexible approach is outlined in the code
+ * comments below.
+ *
  * The default stream-table join behavior of Kafka Streams (below: left join; inner join is similar) only triggers
  * join output when data arrives at the stream side.
  * See https://cwiki.apache.org/confluence/display/KAFKA/Kafka+Streams+Join+Semantics.

--- a/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
@@ -391,8 +391,6 @@ public class CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest {
     final Properties streamsConfiguration = new Properties();
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "table-trigger-join-integration-test");
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArray().getClass().getName());
-    streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
     streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     // Use a temporary directory for storing state, which will be automatically removed after the test.
     streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());

--- a/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
@@ -129,6 +129,14 @@ public class CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest {
     CLUSTER.createTopic(outputTopic);
   }
 
+  /**
+   * Implements the stream-side join behavior of waiting a configurable amount of time for table-side data to arrive
+   * before sending a join output for a newly received stream-side record.
+   *
+   * This behavior will increase the likelihood of "fully populated" join output messages, i.e. with data from both the
+   * stream and the table side.  The downside is that this behavior will increase the end-to-end processing latency for
+   * a stream-side record in the topology.
+   */
   private static final class StreamTableJoinStreamSideTransformerSupplier
     implements TransformerSupplier<String, Double, KeyValue<String, Pair<Double, Long>>> {
 
@@ -214,6 +222,14 @@ public class CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest {
 
   }
 
+  /**
+   * Implements table-side triggering of joint output.
+   *
+   * For every <i>observed </i> record arriving at its upstream table, this transformer will check for a buffered (i.e.,
+   * not yet joined) record on the stream side.  If there is a match, then the transformer will produce a fully
+   * populated join output message -- which is the desired table-side triggering behavior.  If there is no match, then
+   * the transformer will do nothing.
+   */
   private static final class StreamTableJoinTableSideValueTransformerWithKeySupplier
     implements ValueTransformerWithKeySupplier<String, Long, Pair<Double, Long>> {
 

--- a/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.DoubleSerializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.Transformer;
+import org.apache.kafka.streams.kstream.TransformerSupplier;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.test.TestUtils;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
+import io.confluent.examples.streams.utils.InstantSerde;
+import io.confluent.examples.streams.utils.Pair;
+import io.confluent.examples.streams.utils.PairOfDoubleAndLongDeserializer;
+import io.confluent.examples.streams.utils.PairSerde;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end integration test that demonstrates one way to implement a custom join operation.
+ * Here, we implement custom Transformers with the Processor API and plug them into a DSL topology.
+ *
+ * Specifically, this example implements a stream-table join where both the stream side triggers a join output being
+ * sent downstream (default behavior of KStreams) but also the table side (not supported yet in Kafka Streams out of the
+ * box).  When a new record arrives on either side, a join output will be sent downstream immediately only if there is a
+ * matching record on the other side of the join.  If there is no such match, no join output will be sent immediately.
+ * Instead, the arriving record will be buffered to give the other side a certain (configurable) amount of time to,
+ * hopefully, see a matching record to arrive eventually.  However, if the per-key wait time has exceeded, then an
+ * "incomplete" join output will be sent downstream.
+ *
+ * The default stream-table join behavior of Kafka Streams (below: left join; inner join is similar) only triggers
+ * join output when data arrives at the stream side.
+ * See https://cwiki.apache.org/confluence/display/KAFKA/Kafka+Streams+Join+Semantics.
+ *
+ * Kafka Streams INNER stream-table join:
+ *
+ * Time | Stream              Table         | Join output
+ * -----+-----------------------------------+-------------------------
+ * 10   | ("alice", 999.99)                 | -
+ * 20   |                     ("alice", 1L) | -
+ * 30   | ("alice", 555.55)                 | ("alice", (555.55, 1L))
+ *
+ * Kafka Streams LEFT stream-table join:
+ *
+ * Time | Stream              Table         | Join output
+ * -----+-----------------------------------+-------------------------
+ * 10   | ("alice", 999.99)                 | ("alice", (999.99, null)
+ * 20   |                     ("alice", 1L) | -
+ * 30   | ("alice", 555.55)                 | ("alice", (555.55, 1L))
+ *
+ *
+ * The code in this example changes the above behavior so that an application will wait a configurable amount of time
+ * for data to arrive also on the table before it produces the join output for a given key (here: "alice").  Depending
+ * on your use case, you might prefer this changed behavior over the default join semantics of Kafka Streams.
+ *
+ * Time | Stream              Table         | Join output
+ * -----+-----------------------------------+-------------------------
+ * 10   | ("alice", 999.99)                 | -
+ * 20   |                     ("alice", 1L) | ("alice", (999.99, 1L))
+ * 30   | ("alice", 555.55)                 | ("alice", (555.55, 1L))
+ *
+ * Note: This example works with Java 8+ only.
+ */
+public class CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest {
+
+  @ClassRule
+  public static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster();
+
+  private static final String inputTopicForStream = "inputTopicForStream";
+  private static final String inputTopicForTable = "inputTopicForTable";
+  private static final String outputTopic = "outputTopic";
+  private static final String tableStoreName = "table-store";
+
+  @BeforeClass
+  public static void startKafkaCluster() {
+    CLUSTER.createTopic(inputTopicForStream);
+    CLUSTER.createTopic(inputTopicForTable);
+    CLUSTER.createTopic(outputTopic);
+  }
+
+  private static final class StreamTableJoinStreamSideTransformerSupplier
+    implements TransformerSupplier<String, Double, KeyValue<String, Pair<Double, Long>>> {
+
+    private final Duration maxWaitTimePerRecordForTableSideData;
+    private final Duration frequencyToCheckForExpiredWaitTimes;
+    private final String streamBufferStoreName;
+    private final String tableStoreName;
+
+    StreamTableJoinStreamSideTransformerSupplier(final Duration maxWaitTimePerRecordForTableSideData,
+                                                 final Duration frequencyToCheckForExpiredWaitTimes,
+                                                 final String streamBufferStoreName,
+                                                 final String tableStoreName) {
+      this.maxWaitTimePerRecordForTableSideData = maxWaitTimePerRecordForTableSideData;
+      this.frequencyToCheckForExpiredWaitTimes = frequencyToCheckForExpiredWaitTimes;
+      this.streamBufferStoreName = streamBufferStoreName;
+      this.tableStoreName = tableStoreName;
+    }
+
+    @Override
+    public Transformer<String, Double, KeyValue<String, Pair<Double, Long>>> get() {
+      return new Transformer<String, Double, KeyValue<String, Pair<Double, Long>>>() {
+
+        private KeyValueStore<String, Pair<Double, Instant>> streamBufferStore;
+        private KeyValueStore<String, Long> tableStore;
+        private ProcessorContext context;
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void init(final ProcessorContext context) {
+          streamBufferStore = (KeyValueStore<String, Pair<Double, Instant>>) context.getStateStore(streamBufferStoreName);
+          tableStore = (KeyValueStore<String, Long>) context.getStateStore(tableStoreName);
+          this.context = context;
+          // Note: In practice, you will probably want to use `PunctuationType.STREAM_TIME`.  However, using stream time
+          // would make the test/validation setup in this example more complicated, hence we use wall clock time.
+          this.context.schedule(frequencyToCheckForExpiredWaitTimes, PunctuationType.WALL_CLOCK_TIME, this::punctuate);
+        }
+
+        @Override
+        public KeyValue<String, Pair<Double, Long>> transform(final String key, final Double value) {
+          return sendFullJoinRecordOrWaitForTableSide(key, value);
+        }
+
+        private KeyValue<String, Pair<Double, Long>> sendFullJoinRecordOrWaitForTableSide(final String key, final Double value) {
+          final Long tableValue = tableStore.get(key);
+          if (tableValue != null) {
+            // We have data for both the stream and the table, so we can send a fully populated join message downstream
+            // immediately.
+            return KeyValue.pair(key, new Pair<>(value, tableValue));
+          } else {
+            // Don't send a join output just yet because we're still lacking table-side information.  Instead, buffer
+            // the current stream-side record, hoping that the table side will eventually see a matching record within
+            // `maxWaitTimePerRecordForTableSideData`.
+            streamBufferStore.put(key, new Pair<>(value, Instant.now()));
+            return null;
+          }
+        }
+
+        private void punctuate(final long timestamp) {
+          sendAndPurgeAnyWaitingRecordsThatHaveExceededWaitTime(timestamp);
+        }
+
+        private void sendAndPurgeAnyWaitingRecordsThatHaveExceededWaitTime(final long timestamp) {
+          try (KeyValueIterator<String, Pair<Double, Instant>> iterator = streamBufferStore.all()) {
+            while (iterator.hasNext()) {
+              final KeyValue<String, Pair<Double, Instant>> record = iterator.next();
+              final Duration delta = Duration.between(record.value.y, Instant.ofEpochMilli(timestamp));
+              if (delta.compareTo(maxWaitTimePerRecordForTableSideData) > 0) {
+                // Final attempt to fetch table-side data; we use that data even if it is null (indicates: missing).
+                final Long tableValue = tableStore.get(record.key);
+                context.forward(record.key, new Pair<>(record.value.x, tableValue));
+                streamBufferStore.delete(record.key);
+              }
+            }
+          }
+        }
+
+        @Override
+        public void close() {
+        }
+
+      };
+    }
+
+  }
+
+  private static final class StreamTableJoinTableSideValueTransformerWithKeySupplier
+    implements ValueTransformerWithKeySupplier<String, Long, Pair<Double, Long>> {
+
+    final private String streamBufferStoreName;
+
+    StreamTableJoinTableSideValueTransformerWithKeySupplier(final String streamBufferStoreName) {
+      this.streamBufferStoreName = streamBufferStoreName;
+    }
+
+    @Override
+    public ValueTransformerWithKey<String, Long, Pair<Double, Long>> get() {
+      return new ValueTransformerWithKey<String, Long, Pair<Double, Long>>() {
+
+        private KeyValueStore<String, Pair<Double, Instant>> streamBufferStore;
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void init(final ProcessorContext context) {
+          streamBufferStore = (KeyValueStore<String, Pair<Double, Instant>>) context.getStateStore(streamBufferStoreName);
+        }
+
+        @Override
+        public Pair<Double, Long> transform(final String key, final Long value) {
+          return sendJoinRecordOrWaitForStreamSide(key, value);
+        }
+
+        private Pair<Double, Long> sendJoinRecordOrWaitForStreamSide(final String key, final Long value) {
+          if (value != null) {
+            final Pair<Double, Instant> streamValue = streamBufferStore.get(key);
+            if (streamValue != null) {
+              // We have data from both stream and table, so we can send a fully populated join message downstream.
+              streamBufferStore.delete(key);
+              return new Pair<>(streamValue.x, value);
+            } else {
+              return null;
+            }
+          } else {
+            return null;
+          }
+        }
+
+        @Override
+        public void close() {
+        }
+
+      };
+    }
+
+  }
+
+  @Test
+  public void shouldTriggerStreamTableJoinFromTable() throws Exception {
+
+    final List<KeyValue<String, Double>> inputStreamRecords = Arrays.asList(
+      new KeyValue<>("bob", 888.88),
+      new KeyValue<>("alice", 999.99)
+    );
+
+    final List<KeyValue<String, Long>> inputTableRecords = Arrays.asList(
+      new KeyValue<>("alice", 1L),
+      new KeyValue<>("alice", 2L)
+    );
+
+    final List<KeyValue<String, Pair<Double, Long>>> expectedRecords = Arrays.asList(
+      // The join output will have 2L (not 1L) for the table side.  That's because, by default, the DSL enables record
+      // caching for tables, which will cause the ValueTransformerWithKey for the KTable to not see the 1L value.
+      //
+      // If your use case needs to see a join output with value 1L, there are several options available.
+      //
+      // 1) Set `StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG` to `0`.  This will disable record caching,
+      //    and make the table's ValueTransformerWithKey to see the 1L value.  The downside of this approach is that,
+      //    by definition, record caching is disabled for the complete topology, resulting in a larger volume of
+      //    "intermediate" updates.
+      // 2) Don't use a KTable and a ValueTransformerWithKeySupplier for managing the table-side triggering for the
+      //    join.  Instead, read the table's topic into a KStream, and then use a normal Transformer with code very
+      //    similar to what's implement in StreamTableJoinStreamSideTransformerSupplier.  You must also create a second
+      //    state store, managed by this new table-side Transformer, to manage the table-side store manually (because
+      //    you use a KStream instead of a KTable for the table's data).  Now you have full control over when and how to
+      //    perform table-side join triggering.
+      //
+      // Note: Kafka Streams' current stream-table join semantics dictate that only a single join output will ever be
+      //       produced for a newly arriving stream-side record.  Table-side triggering of the join should only be used
+      //       to ensure (rather: to increase the chance) that, when a join output is actually produced, it contains
+      //       data from both the stream and the table.  However, table-side triggering should NOT be used to sent
+      //       multiple join outputs for the same stream-side record.
+      //
+      //       Example of wrong table-side join triggering:
+      //
+      //          Time | Stream              Table         | Join output
+      //          -----+-----------------------------------+------------------------
+      //          10   | ("alice", 999.99)                 |
+      //          20   |                     ("alice", 1L) | ("alice", (999.99, 1L))
+      //          30   |                     ("alice", 2L) | ("alice", (999.99, 2L))
+      //
+      //       In the wrong example above, only one join output must be produced, not two.  It's up to you to decide
+      //       which one, however.
+      //
+      new KeyValue<>("alice", new Pair<>(999.99, 2L)),
+      new KeyValue<>("bob", new Pair<>(888.88, null))
+    );
+
+    //
+    // Step 1: Configure and start the processor topology.
+    //
+    final StreamsBuilder builder = new StreamsBuilder();
+
+    final Properties streamsConfiguration = new Properties();
+    streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "table-trigger-join-integration-test");
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+    streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArray().getClass().getName());
+    streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+    streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    // Use a temporary directory for storing state, which will be automatically removed after the test.
+    streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
+
+    // This state store is used to temporarily buffer any records arriving at the stream side of the join, so that
+    // we can wait (if needed) on matching data to arrive at the table side.
+    final StoreBuilder<KeyValueStore<String, Pair<Double, Instant>>> streamBufferStateStore =
+      Stores
+        .keyValueStoreBuilder(
+          Stores.persistentKeyValueStore("stream-buffer-state-store"),
+          Serdes.String(),
+          new PairSerde<>(Serdes.Double(), new InstantSerde())
+        )
+        .withCachingEnabled();
+    builder.addStateStore(streamBufferStateStore);
+
+    // Read the input data.
+    final KStream<String, Double> stream = builder.stream(inputTopicForStream, Consumed.with(Serdes.String(), Serdes.Double()));
+    final KTable<String, Long> table =
+      builder.table(inputTopicForTable, Consumed.with(Serdes.String(), Serdes.Long()), Materialized.as(tableStoreName));
+
+    // Perform the custom join operation.
+    final Duration maxWaitTimePerRecordForTableSideData = Duration.ofSeconds(5);
+    final Duration frequencyToCheckForExpiredWaitTimes = Duration.ofSeconds(2);
+    final KStream<String, Pair<Double, Long>> transformedStream =
+      stream.transform(
+        new StreamTableJoinStreamSideTransformerSupplier(
+          maxWaitTimePerRecordForTableSideData,
+          frequencyToCheckForExpiredWaitTimes,
+          streamBufferStateStore.name(), tableStoreName),
+        streamBufferStateStore.name(), tableStoreName);
+    final KTable<String, Pair<Double, Long>> transformedTable =
+      table.transformValues(
+        new StreamTableJoinTableSideValueTransformerWithKeySupplier(streamBufferStateStore.name()),
+        streamBufferStateStore.name());
+    final KStream<String, Pair<Double, Long>> mergedStream = transformedStream.merge(transformedTable.toStream());
+
+    // Write the join results back to Kafka.
+    mergedStream.to(outputTopic, Produced.with(Serdes.String(), new PairSerde<>(Serdes.Double(), Serdes.Long())));
+
+    // Start the topology.
+    final KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfiguration);
+    streams.start();
+
+    //
+    // Step 2: Produce some input data to the input topics.
+    //
+
+    // Produce input data for the stream
+    final Properties producerConfigStream = new Properties();
+    producerConfigStream.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+    producerConfigStream.put(ProducerConfig.ACKS_CONFIG, "all");
+    producerConfigStream.put(ProducerConfig.RETRIES_CONFIG, 0);
+    producerConfigStream.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    producerConfigStream.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, DoubleSerializer.class);
+    IntegrationTestUtils.produceKeyValuesSynchronously(inputTopicForStream, inputStreamRecords, producerConfigStream);
+
+    // Produce input data for the table
+    final Properties producerConfigTable = new Properties();
+    producerConfigTable.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+    producerConfigTable.put(ProducerConfig.ACKS_CONFIG, "all");
+    producerConfigTable.put(ProducerConfig.RETRIES_CONFIG, 0);
+    producerConfigTable.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    producerConfigTable.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+    IntegrationTestUtils.produceKeyValuesSynchronously(inputTopicForTable, inputTableRecords, producerConfigTable);
+
+    //
+    // Step 3: Verify the application's output data.
+    //
+    final Properties consumerConfig = new Properties();
+    consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+    consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "table-trigger-join-integration-test-standard-consumer");
+    consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, PairOfDoubleAndLongDeserializer.class);
+    final List<KeyValue<String, Long>> actualRecords = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
+      consumerConfig,
+      outputTopic,
+      expectedRecords.size()
+    );
+    streams.close();
+    assertThat(actualRecords).isEqualTo(expectedRecords);
+  }
+
+}

--- a/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
@@ -84,12 +84,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * KTable (thus avoiding data duplication due to store usage), whereas the state store on the stream side is manually
  * added and attached to the processing topology.
  *
- * An alternative, more flexible approach is outlined in the code comments below, in case you need additional control
- * over the join behavior, e.g. by including stream-side vs. table-side timestamps in the decision-making logic.
+ * An alternative, more flexible approach is outlined further down below, in case you need additional control over the
+ * join behavior, e.g. by including stream-side vs. table-side timestamps in the decision-making logic.
  *
- * The default stream-table join behavior of Kafka Streams (below: left join; inner join is similar) only triggers
- * join output when data arrives at the stream side.
- * See https://cwiki.apache.org/confluence/display/KAFKA/Kafka+Streams+Join+Semantics.
+ * The default stream-table join behavior of Kafka Streams only triggers join output when data arrives at the stream
+ * side.  See https://cwiki.apache.org/confluence/display/KAFKA/Kafka+Streams+Join+Semantics.
  *
  * Kafka Streams INNER stream-table join:
  *

--- a/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
@@ -110,7 +110,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * The code in this example changes the above behavior so that an application will wait a configurable amount of time
  * for data to arrive also at the table before it produces the join output for a given key (here: "alice").  The
  * motivation is that, in this example, we'd prefer to receive fully populated join messages rather than join messages
- * were the table-side information is missing (null).  Depending on your use case, you might prefer this changed
+ * where the table-side information is missing (null).  Depending on your use case, you might prefer this changed
  * behavior, and these changed semantics, over the default join semantics of Kafka Streams.
  *
  * Time | Stream              Table         | Join output

--- a/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
@@ -339,18 +339,18 @@ public class CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest {
         @Override
         public KeyValue<String, Pair<Double, Long>> transform(final String key, final Double value) {
           LOG.info("Received stream record ({}, {}) with timestamp {}", key, value, context.timestamp());
-          sendAnyBufferedRecordForKey(key);
+          sendAnyWaitingRecordForKey(key);
           return sendFullJoinRecordOrWaitForTableSide(key, value);
         }
 
-        private void sendAnyBufferedRecordForKey(final String key) {
-          LOG.info("Forwarding any buffered stream record for key {} because new stream record was received for same " +
+        private void sendAnyWaitingRecordForKey(final String key) {
+          LOG.info("Forwarding any waiting stream record for key {} because new stream record was received for same " +
             "key", key);
           final Pair<Double, Instant> record = streamBufferStore.get(key);
           if (record != null) {
             final Long tableValue = tableStore.get(key);
             final Pair<Double, Long> joinRecord = new Pair<>(record.x, tableValue);
-            LOG.info("Force-forwarding buffered stream record ({}, {}) because new stream record received for key {}",
+            LOG.info("Force-forwarding waiting stream record ({}, {}) because new stream record received for key {}",
               key, joinRecord, key);
             context.forward(key, joinRecord);
             streamBufferStore.delete(key);

--- a/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
@@ -183,18 +183,25 @@ public class CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest {
 
     final List<KeyValueWithTimestamp<String, Double>> inputStreamRecords = Arrays.asList(
       new KeyValueWithTimestamp<>("alice", 999.99, 10),
+      new KeyValueWithTimestamp<>("bobby", 222.22, 15),
       new KeyValueWithTimestamp<>("alice", 555.55, 30),
+      new KeyValueWithTimestamp<>("alice", 666.66, 40),
       new KeyValueWithTimestamp<>("recordUsedOnlyToTriggerAdvancementOfStreamTime", 77777.77,
         approxMaxWaitTimePerRecordForTableData.plus(Duration.ofSeconds(1)).toMillis())
     );
 
-    final List<KeyValueWithTimestamp<String, Long>> inputTableRecords = Collections.singletonList(
-      new KeyValueWithTimestamp<>("alice", 1L, 20)
+    final List<KeyValueWithTimestamp<String, Long>> inputTableRecords = Arrays.asList(
+      new KeyValueWithTimestamp<>("alice", 1L, 20),
+      new KeyValueWithTimestamp<>("alice", 2L, 39),
+      new KeyValueWithTimestamp<>("bobby", 8L,
+        approxMaxWaitTimePerRecordForTableData.plus(Duration.ofSeconds(1)).toMillis())
     );
 
     final List<KeyValue<String, Pair<Double, Long>>> expectedOutputRecords = Arrays.asList(
       new KeyValue<>("alice", new Pair<>(999.99, 1L)),
-      new KeyValue<>("alice", new Pair<>(555.55, 1L))
+      new KeyValue<>("alice", new Pair<>(555.55, 1L)),
+      new KeyValue<>("alice", new Pair<>(666.66, 2L)),
+      new KeyValue<>("bobby", new Pair<>(222.22, null))
     );
 
     //

--- a/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
@@ -230,10 +230,10 @@ public class CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest {
 
         @Override
         public Pair<Double, Long> transform(final String key, final Long value) {
-          return sendJoinRecordOrWaitForStreamSide(key, value);
+          return possiblySendFullJoinRecord(key, value);
         }
 
-        private Pair<Double, Long> sendJoinRecordOrWaitForStreamSide(final String key, final Long value) {
+        private Pair<Double, Long> possiblySendFullJoinRecord(final String key, final Long value) {
           if (value != null) {
             final Pair<Double, Instant> streamValue = streamBufferStore.get(key);
             if (streamValue != null) {

--- a/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
@@ -191,8 +191,8 @@ public class CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest {
               if (delta.compareTo(maxWaitTimePerRecordForTableSideData) > 0) {
                 // Final attempt to fetch table-side data; we use that data even if it is null (indicates: missing).
                 final Long tableValue = tableStore.get(record.key);
-                context.forward(record.key, new Pair<>(record.value.x, tableValue));
                 streamBufferStore.delete(record.key);
+                context.forward(record.key, new Pair<>(record.value.x, tableValue));
               }
             }
           }

--- a/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest.java
@@ -346,7 +346,7 @@ public class CustomJoinWithTableTriggeringStreamTableJoinIntegrationTest {
     streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
 
     // This state store is used to temporarily buffer any records arriving at the stream side of the join, so that
-    // we can wait (if needed) on matching data to arrive at the table side.
+    // we can wait (if needed) for matching data to arrive at the table side.
     final StoreBuilder<KeyValueStore<String, Pair<Double, Instant>>> streamBufferStateStore =
       Stores
         .keyValueStoreBuilder(

--- a/src/test/java/io/confluent/examples/streams/utils/InstantDeserializer.java
+++ b/src/test/java/io/confluent/examples/streams/utils/InstantDeserializer.java
@@ -35,8 +35,7 @@ public class InstantDeserializer implements Deserializer<Instant> {
       return null;
     }
     final Instant instant;
-    try {
-      final DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes));
+    try (final DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes))) {
       final long secsSinceEpoch = in.readLong();
       final int nanoSecsFromStartOfSecond = in.readInt();
       instant = Instant.ofEpochSecond(secsSinceEpoch, nanoSecsFromStartOfSecond);

--- a/src/test/java/io/confluent/examples/streams/utils/InstantDeserializer.java
+++ b/src/test/java/io/confluent/examples/streams/utils/InstantDeserializer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams.utils;
+
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+
+public class InstantDeserializer implements Deserializer<Instant> {
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+  }
+
+  @Override
+  public Instant deserialize(final String topic, final byte[] bytes) {
+    if (bytes == null || bytes.length == 0) {
+      return null;
+    }
+    final Instant instant;
+    try {
+      final DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes));
+      final long secsSinceEpoch = in.readLong();
+      final int nanoSecsFromStartOfSecond = in.readInt();
+      instant = Instant.ofEpochSecond(secsSinceEpoch, nanoSecsFromStartOfSecond);
+    } catch (final IOException e) {
+      throw new RuntimeException("Unable to deserialize Pair", e);
+    }
+    return instant;
+  }
+
+  @Override
+  public void close() {
+  }
+
+}

--- a/src/test/java/io/confluent/examples/streams/utils/InstantSerde.java
+++ b/src/test/java/io/confluent/examples/streams/utils/InstantSerde.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams.utils;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.time.Instant;
+import java.util.Map;
+
+public class InstantSerde implements Serde<Instant> {
+
+  private final Serde<Instant> inner = Serdes.serdeFrom(new InstantSerializer(), new InstantDeserializer());
+
+  @Override
+  public Serializer<Instant> serializer() {
+    return inner.serializer();
+  }
+
+  @Override
+  public Deserializer<Instant> deserializer() {
+    return inner.deserializer();
+  }
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+    inner.serializer().configure(configs, isKey);
+    inner.deserializer().configure(configs, isKey);
+  }
+
+  @Override
+  public void close() {
+    inner.serializer().close();
+    inner.deserializer().close();
+  }
+
+}

--- a/src/test/java/io/confluent/examples/streams/utils/InstantSerdeTest.java
+++ b/src/test/java/io/confluent/examples/streams/utils/InstantSerdeTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams.utils;
+
+import org.junit.Test;
+
+import java.time.Instant;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class InstantSerdeTest {
+
+  @Test
+  public void shouldRoundTrip() {
+    // Given
+    final Instant instant = Instant.ofEpochSecond(5L, 4);
+    final String anyTopic = "ANY_TOPIC";
+    final InstantSerde instantSerde = new InstantSerde();
+
+    // When
+    final byte[] serializedBytes = instantSerde.serializer().serialize(anyTopic, instant);
+    final Instant deserializedInstant = instantSerde.deserializer().deserialize(anyTopic, serializedBytes);
+
+    // Then
+    assertThat(deserializedInstant, equalTo(instant));
+  }
+
+  @Test
+  public void shouldSupportNull() {
+    // Given
+    final Instant instant = null;
+    final String anyTopic = "ANY_TOPIC";
+    final InstantSerde instantSerde = new InstantSerde();
+
+    // When
+    final byte[] serializedBytes = instantSerde.serializer().serialize(anyTopic, instant);
+    final Instant deserializedInstant = instantSerde.deserializer().deserialize(anyTopic, serializedBytes);
+
+    // Then
+    assertThat(deserializedInstant, equalTo(instant));
+  }
+
+}

--- a/src/test/java/io/confluent/examples/streams/utils/InstantSerializer.java
+++ b/src/test/java/io/confluent/examples/streams/utils/InstantSerializer.java
@@ -34,18 +34,19 @@ public class InstantSerializer implements Serializer<Instant> {
     if (instant == null) {
       return null;
     }
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    try {
-      final DataOutputStream out = new DataOutputStream(baos);
+    try (
+      final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      final DataOutputStream out = new DataOutputStream(baos)
+    ) {
       final long secsSinceEpoch = instant.getEpochSecond();
       final int nanoSecsFromStartOfSecond = instant.getNano();
       out.writeLong(secsSinceEpoch);
       out.writeInt(nanoSecsFromStartOfSecond);
       out.close();
+      return baos.toByteArray();
     } catch (final IOException e) {
       throw new RuntimeException("unable to serialize Instant", e);
     }
-    return baos.toByteArray();
   }
 
   @Override

--- a/src/test/java/io/confluent/examples/streams/utils/InstantSerializer.java
+++ b/src/test/java/io/confluent/examples/streams/utils/InstantSerializer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams.utils;
+
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+
+public class InstantSerializer implements Serializer<Instant> {
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+  }
+
+  @Override
+  public byte[] serialize(final String topic, final Instant instant) {
+    if (instant == null) {
+      return null;
+    }
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try {
+      final DataOutputStream out = new DataOutputStream(baos);
+      final long secsSinceEpoch = instant.getEpochSecond();
+      final int nanoSecsFromStartOfSecond = instant.getNano();
+      out.writeLong(secsSinceEpoch);
+      out.writeInt(nanoSecsFromStartOfSecond);
+      out.close();
+    } catch (final IOException e) {
+      throw new RuntimeException("unable to serialize Instant", e);
+    }
+    return baos.toByteArray();
+  }
+
+  @Override
+  public void close() {
+  }
+
+}

--- a/src/test/java/io/confluent/examples/streams/utils/InstantSerializer.java
+++ b/src/test/java/io/confluent/examples/streams/utils/InstantSerializer.java
@@ -42,7 +42,6 @@ public class InstantSerializer implements Serializer<Instant> {
       final int nanoSecsFromStartOfSecond = instant.getNano();
       out.writeLong(secsSinceEpoch);
       out.writeInt(nanoSecsFromStartOfSecond);
-      out.close();
       return baos.toByteArray();
     } catch (final IOException e) {
       throw new RuntimeException("unable to serialize Instant", e);

--- a/src/test/java/io/confluent/examples/streams/utils/KeyValueWithTimestamp.java
+++ b/src/test/java/io/confluent/examples/streams/utils/KeyValueWithTimestamp.java
@@ -1,0 +1,21 @@
+package io.confluent.examples.streams.utils;
+
+import org.apache.kafka.streams.KeyValue;
+
+public class KeyValueWithTimestamp<K, V> extends KeyValue<K, V> {
+
+  /**
+   * Timestamp of Kafka message (milliseconds since the epoch).
+   */
+  public final long timestamp;
+
+  public KeyValueWithTimestamp(final K key, final V value, final long timestamp) {
+    super(key, value);
+    this.timestamp = timestamp;
+  }
+
+  public KeyValueWithTimestamp(final K key, final V value) {
+    this(key, value, System.currentTimeMillis());
+  }
+
+}

--- a/src/test/java/io/confluent/examples/streams/utils/KeyValueWithTimestamp.java
+++ b/src/test/java/io/confluent/examples/streams/utils/KeyValueWithTimestamp.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.confluent.examples.streams.utils;
 
 import org.apache.kafka.streams.KeyValue;

--- a/src/test/java/io/confluent/examples/streams/utils/Pair.java
+++ b/src/test/java/io/confluent/examples/streams/utils/Pair.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams.utils;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class Pair<X, Y> implements Serializable {
+
+  public final X x;
+  public final Y y;
+
+  public Pair(final X x, final Y y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  @Override
+  public String toString() {
+    return "(" + x + ", " + y + ")";
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final Pair<?, ?> pair = (Pair<?, ?>) o;
+    return Objects.equals(x, pair.x) &&
+      Objects.equals(y, pair.y);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(x, y);
+  }
+}

--- a/src/test/java/io/confluent/examples/streams/utils/PairDeserializer.java
+++ b/src/test/java/io/confluent/examples/streams/utils/PairDeserializer.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams.utils;
+
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.Map;
+
+public class PairDeserializer<X, Y> implements Deserializer<Pair<X, Y>> {
+
+  private final Deserializer<X> deserializerX;
+  private final Deserializer<Y> deserializerY;
+
+  public PairDeserializer(final Deserializer<X> deserializerX, final Deserializer<Y> deserializerY) {
+    this.deserializerX = deserializerX;
+    this.deserializerY = deserializerY;
+  }
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+  }
+
+  @Override
+  public Pair<X, Y> deserialize(final String topic, final byte[] bytes) {
+    if (bytes == null || bytes.length == 0) {
+      return null;
+    }
+    final Pair<X, Y> pair;
+    try {
+      final DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes));
+      final short magicByte = in.readShort();
+      X deserializedX = null;
+      Y deserializedY = null;
+      if (magicByte == 1) {
+        deserializedX = readX(in, topic);
+      }
+      if (magicByte == 2) {
+        deserializedY = readY(in, topic);
+      }
+      if (magicByte == 3) {
+        deserializedX = readX(in, topic);
+        deserializedY = readY(in, topic);
+      }
+      pair = new Pair<>(deserializedX, deserializedY);
+    } catch (
+      final IOException e)
+
+    {
+      throw new RuntimeException("Unable to deserialize Pair", e);
+    }
+    return pair;
+  }
+
+  private X readX(final DataInputStream in, final String topic) throws IOException {
+    final int xLength = in.readInt();
+    final byte[] serializedX = new byte[xLength];
+    in.readFully(serializedX);
+    return deserializerX.deserialize(topic, serializedX);
+  }
+
+  private Y readY(final DataInputStream in, final String topic) throws IOException {
+    final int yLength = in.readInt();
+    final byte[] serializedY = new byte[yLength];
+    in.readFully(serializedY);
+    return deserializerY.deserialize(topic, serializedY);
+  }
+
+  @Override
+  public void close() {
+  }
+
+}

--- a/src/test/java/io/confluent/examples/streams/utils/PairDeserializer.java
+++ b/src/test/java/io/confluent/examples/streams/utils/PairDeserializer.java
@@ -42,8 +42,7 @@ public class PairDeserializer<X, Y> implements Deserializer<Pair<X, Y>> {
       return null;
     }
     final Pair<X, Y> pair;
-    try {
-      final DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes));
+    try (final DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes))) {
       final short magicByte = in.readShort();
       X deserializedX = null;
       Y deserializedY = null;

--- a/src/test/java/io/confluent/examples/streams/utils/PairOfDoubleAndLongDeserializer.java
+++ b/src/test/java/io/confluent/examples/streams/utils/PairOfDoubleAndLongDeserializer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams.utils;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.DoubleDeserializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+
+import java.util.Map;
+
+public class PairOfDoubleAndLongDeserializer implements Deserializer<Pair<Double, Long>> {
+
+  public PairOfDoubleAndLongDeserializer() {
+  }
+
+  final private Deserializer<Pair<Double, Long>> inner =
+    new PairDeserializer<>(new DoubleDeserializer(), new LongDeserializer());
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+  }
+
+  @Override
+  public Pair<Double, Long> deserialize(final String topic, final byte[] bytes) {
+    return inner.deserialize(topic, bytes);
+  }
+
+  @Override
+  public void close() {
+
+  }
+}

--- a/src/test/java/io/confluent/examples/streams/utils/PairSerde.java
+++ b/src/test/java/io/confluent/examples/streams/utils/PairSerde.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams.utils;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.Map;
+
+public class PairSerde<X, Y> implements Serde<Pair<X, Y>> {
+
+  private final Serde<Pair<X, Y>> inner;
+
+  public PairSerde(final Serde<X> serdeX, final Serde<Y> serdeY) {
+    inner = Serdes.serdeFrom(
+      new PairSerializer<>(serdeX.serializer(), serdeY.serializer()),
+      new PairDeserializer<>(serdeX.deserializer(), serdeY.deserializer()));
+  }
+
+  @Override
+  public Serializer<Pair<X, Y>> serializer() {
+    return inner.serializer();
+  }
+
+  @Override
+  public Deserializer<Pair<X, Y>> deserializer() {
+    return inner.deserializer();
+  }
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+    inner.serializer().configure(configs, isKey);
+    inner.deserializer().configure(configs, isKey);
+  }
+
+  @Override
+  public void close() {
+    inner.serializer().close();
+    inner.deserializer().close();
+  }
+
+}

--- a/src/test/java/io/confluent/examples/streams/utils/PairSerdeTest.java
+++ b/src/test/java/io/confluent/examples/streams/utils/PairSerdeTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams.utils;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class PairSerdeTest {
+
+  @Test
+  public void shouldRoundTrip() {
+    // Given
+    final Pair<String, Long> pair = new Pair<>("foo", 5L);
+    final String anyTopic = "ANY_TOPIC";
+    final PairSerde<String, Long> pairSerde = new PairSerde<>(Serdes.String(), Serdes.Long());
+
+    // When
+    final byte[] serializedBytes = pairSerde.serializer().serialize(anyTopic, pair);
+    final Pair<String, Long> deserializedPair = pairSerde.deserializer().deserialize(anyTopic, serializedBytes);
+
+    // Then
+    assertThat(deserializedPair, equalTo(pair));
+  }
+
+
+  @Test
+  public void shouldSupportNullForX() {
+    // Given
+    final Pair<String, Long> pair = new Pair<>(null, 5L);
+    final String anyTopic = "ANY_TOPIC";
+    final PairSerde<String, Long> pairSerde = new PairSerde<>(Serdes.String(), Serdes.Long());
+
+    // When
+    final byte[] serializedBytes = pairSerde.serializer().serialize(anyTopic, pair);
+    final Pair<String, Long> deserializedPair = pairSerde.deserializer().deserialize(anyTopic, serializedBytes);
+
+    // Then
+    assertThat(deserializedPair, equalTo(pair));
+  }
+
+  @Test
+  public void shouldSupportNullForY() {
+    // Given
+    final Pair<String, Long> pair = new Pair<>("foo", null);
+    final String anyTopic = "ANY_TOPIC";
+    final PairSerde<String, Long> pairSerde = new PairSerde<>(Serdes.String(), Serdes.Long());
+
+    // When
+    final byte[] serializedBytes = pairSerde.serializer().serialize(anyTopic, pair);
+    final Pair<String, Long> deserializedPair = pairSerde.deserializer().deserialize(anyTopic, serializedBytes);
+
+    // Then
+    assertThat(deserializedPair, equalTo(pair));
+  }
+
+  @Test
+  public void shouldSupportNullForXAndY() {
+    // Given
+    final Pair<String, Long> pair = new Pair<>(null, null);
+    final String anyTopic = "ANY_TOPIC";
+    final PairSerde<String, Long> pairSerde = new PairSerde<>(Serdes.String(), Serdes.Long());
+
+    // When
+    final byte[] serializedBytes = pairSerde.serializer().serialize(anyTopic, pair);
+    final Pair<String, Long> deserializedPair = pairSerde.deserializer().deserialize(anyTopic, serializedBytes);
+
+    // Then
+    assertThat(deserializedPair, equalTo(pair));
+  }
+
+  @Test
+  public void shouldSupportNullReference() {
+    // Given
+    final Pair<String, Long> pair = null;
+    final String anyTopic = "ANY_TOPIC";
+    final PairSerde<String, Long> pairSerde = new PairSerde<>(Serdes.String(), Serdes.Long());
+
+    // When
+    final byte[] serializedBytes = pairSerde.serializer().serialize(anyTopic, pair);
+    final Pair<String, Long> deserializedPair = pairSerde.deserializer().deserialize(anyTopic, serializedBytes);
+
+    // Then
+    assertThat(deserializedPair, equalTo(pair));
+  }
+
+}

--- a/src/test/java/io/confluent/examples/streams/utils/PairSerializer.java
+++ b/src/test/java/io/confluent/examples/streams/utils/PairSerializer.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams.utils;
+
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Map;
+
+public class PairSerializer<X, Y> implements Serializer<Pair<X, Y>> {
+
+  private final Serializer<X> serializerX;
+  private final Serializer<Y> serializerY;
+
+  public PairSerializer(final Serializer<X> serializerX, final Serializer<Y> serializerY) {
+    this.serializerX = serializerX;
+    this.serializerY = serializerY;
+  }
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+  }
+
+  @Override
+  public byte[] serialize(final String topic, final Pair<X, Y> pair) {
+    if (pair == null) {
+      return null;
+    }
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try {
+      final DataOutputStream out = new DataOutputStream(baos);
+      final byte[] serializedX = serializerX.serialize(topic, pair.x);
+      final byte[] serializedY = serializerY.serialize(topic, pair.y);
+      short magicByte = 0;
+      if (serializedX != null) {
+        magicByte += 1;
+      }
+      if (serializedY != null) {
+        magicByte += 2;
+      }
+      out.writeShort(magicByte);
+      if (magicByte == 1) {
+        writeX(out, serializedX);
+      }
+      if (magicByte == 2) {
+        writeY(out, serializedY);
+      }
+      if (magicByte == 3) {
+        writeX(out, serializedX);
+        writeY(out, serializedY);
+      }
+      out.close();
+    } catch (final IOException e) {
+      throw new RuntimeException("unable to serialize Pair", e);
+    }
+    return baos.toByteArray();
+  }
+
+  private void writeX(final DataOutputStream out, final byte[] serializedX) throws IOException {
+    out.writeInt(serializedX.length);
+    out.write(serializedX);
+  }
+
+  private void writeY(final DataOutputStream out, final byte[] serializedY) throws IOException {
+    out.writeInt(serializedY.length);
+    out.write(serializedY);
+  }
+
+  @Override
+  public void close() {
+  }
+
+}

--- a/src/test/java/io/confluent/examples/streams/utils/PairSerializer.java
+++ b/src/test/java/io/confluent/examples/streams/utils/PairSerializer.java
@@ -41,9 +41,11 @@ public class PairSerializer<X, Y> implements Serializer<Pair<X, Y>> {
     if (pair == null) {
       return null;
     }
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    try {
-      final DataOutputStream out = new DataOutputStream(baos);
+
+    try (
+      final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      final DataOutputStream out = new DataOutputStream(baos)
+    ) {
       final byte[] serializedX = serializerX.serialize(topic, pair.x);
       final byte[] serializedY = serializerY.serialize(topic, pair.y);
       short magicByte = 0;
@@ -64,11 +66,10 @@ public class PairSerializer<X, Y> implements Serializer<Pair<X, Y>> {
         writeX(out, serializedX);
         writeY(out, serializedY);
       }
-      out.close();
+      return baos.toByteArray();
     } catch (final IOException e) {
       throw new RuntimeException("unable to serialize Pair", e);
     }
-    return baos.toByteArray();
   }
 
   private void writeX(final DataOutputStream out, final byte[] serializedX) throws IOException {

--- a/src/test/java/io/confluent/examples/streams/utils/PairTest.java
+++ b/src/test/java/io/confluent/examples/streams/utils/PairTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams.utils;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class PairTest {
+
+  @Test
+  public void shouldSupportEquals() {
+    // Given
+    final Pair<String, String> pair = new Pair<>("foo", "bar");
+
+    // When/Then
+    assertThat(new Pair<>("foo", "bar"), equalTo(pair));
+    assertThat(null, not(equalTo(pair)));
+    assertThat(new Pair<>("foo", "quux"), not(equalTo(pair)));
+    assertThat(new Pair<>("quux", "foo"), not(equalTo(pair)));
+    assertThat(new Pair<>("foo", 1), not(equalTo(pair)));
+    assertThat(new Pair<>(1, "foo"), not(equalTo(pair)));
+  }
+
+}

--- a/src/test/java/io/confluent/examples/streams/utils/PriorityQueueSerdeTest.java
+++ b/src/test/java/io/confluent/examples/streams/utils/PriorityQueueSerdeTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class PriorityQueueSerdeTest {
 
     @Test
-    public void shouldSerializeDeserialize() throws Exception {
+    public void shouldSerializeDeserialize() {
         final Comparator<Long> comparator = Long::compareTo;
         final PriorityQueue<Long> queue = new PriorityQueue<>(comparator);
         queue.add(2L);


### PR DESCRIPTION
Adds an end-to-end integration test that demonstrates one way to implement a custom join operation. Here, we implement custom Transformers with the Processor API and plug them into a DSL topology.

Specifically, this example implements a stream-table join where both the stream side triggers a join output being sent downstream (default behavior of KStreams) but also the table side (not supported yet in KStreams out of the box).  When a new record arrives on either side, a join output will be sent downstream immediately only if there is a matching record on the other side of the join.  If there is no such match, no join output will be sent immediately. Instead, the arriving record will be buffered to give the other side a certain (configurable) amount of time to, hopefully, see a matching record to arrive eventually.  However, if the per-key wait time has exceeded, then an "incomplete" join output will be sent downstream.

**Testing:** tests pass locally.