### PR TITLE
Increase SR timeout; backport of PR #41

### DIFF
--- a/src/test/java/io/confluent/examples/streams/GlobalKTablesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/GlobalKTablesExampleTest.java
@@ -19,6 +19,7 @@ import io.confluent.examples.streams.avro.EnrichedOrder;
 import io.confluent.examples.streams.avro.Order;
 import io.confluent.examples.streams.avro.Product;
 import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
@@ -50,7 +51,13 @@ import static org.hamcrest.core.IsCollectionContaining.hasItem;
 public class GlobalKTablesExampleTest {
 
   @ClassRule
-  public static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster();
+  public static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster(
+    new Properties() {
+      {
+        put(SchemaRegistryConfig.KAFKASTORE_TIMEOUT_CONFIG, "30000");
+      }
+    }
+  );
   private KafkaStreams streamInstanceOne;
   private KafkaStreams streamInstanceTwo;
 

--- a/src/test/java/io/confluent/examples/streams/microservices/util/MicroserviceTestUtils.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/util/MicroserviceTestUtils.java
@@ -7,6 +7,7 @@ import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.examples.streams.microservices.domain.Schemas;
 import io.confluent.examples.streams.microservices.domain.Schemas.Topic;
 import io.confluent.examples.streams.microservices.domain.Schemas.Topics;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import kafka.server.KafkaConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -43,12 +44,13 @@ public class MicroserviceTestUtils {
   @ClassRule
   public static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster(
       MicroserviceTestUtils.propsWith(
-          //Transactions need durability so the defaults require multiple nodes.
-          //For testing purposes set transactions to work with a single kafka broker.
-          new KeyValue<>(KafkaConfig.TransactionsTopicReplicationFactorProp(), "1"),
-          new KeyValue<>(KafkaConfig.TransactionsTopicMinISRProp(), "1"),
-          new KeyValue<>(KafkaConfig.TransactionsTopicPartitionsProp(), "1")
-      ));
+        //Transactions need durability so the defaults require multiple nodes.
+        //For testing purposes set transactions to work with a single kafka broker.
+        new KeyValue<>(KafkaConfig.TransactionsTopicReplicationFactorProp(), "1"),
+        new KeyValue<>(KafkaConfig.TransactionsTopicMinISRProp(), "1"),
+        new KeyValue<>(KafkaConfig.TransactionsTopicPartitionsProp(), "1"),
+        new KeyValue<>(SchemaRegistryConfig.KAFKASTORE_TIMEOUT_CONFIG, "30000")
+    ));
 
   @AfterClass
   public static void stopCluster() {


### PR DESCRIPTION
`EndToEndTest.shouldProcessManyInvalidOrdersEndToEnd` failed in https://jenkins.confluent.io/job/confluentinc/job/kafka-streams-examples/job/3.3.x/727 with

```
javax.ws.rs.ServerErrorException: HTTP 504 Gateway Timeout
	at io.confluent.examples.streams.microservices.EndToEndTest.shouldProcessManyInvalidOrdersEndToEnd(EndToEndTest.java:121)
```

This is a known issue and was fixed with https://github.com/confluentinc/kafka-streams-examples/pull/41 in `4.0` already -- not sure why we did not do the fix in `3.3` to begin with.

This PR back ports the fix (ie, increase SR timeout) only (not the applied code cleanup).

When merging, this should not to into 4.0 and later branches.