### PR TITLE
MINOR: Fix some compiler warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
                         <arg>-Ywarn-adapted-args</arg>
                         <arg>-Ywarn-dead-code</arg>
                         <!-- Fail on compiler warnings -->
-                        <!--<arg>-Xfatal-warnings</arg>-->
+                        <!--TODO: enable this once we have warnings under control<arg>-Xfatal-warnings</arg>-->
                     </args>
                 </configuration>
                 <executions>
@@ -365,7 +365,7 @@
                     <target>${java.version}</target>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
-                        <!--<arg>-Werror</arg>-->
+                        <!--TODO: enable this once we have warnings under control<arg>-Werror</arg>-->
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,8 @@
                         <!-- Warn if an argument list is modified to match the receiver. -->
                         <arg>-Ywarn-adapted-args</arg>
                         <arg>-Ywarn-dead-code</arg>
+                        <!-- Fail on compiler warnings -->
+                        <!--<arg>-Xfatal-warnings</arg>-->
                     </args>
                 </configuration>
                 <executions>
@@ -361,6 +363,10 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                        <!--<arg>-Werror</arg>-->
+                    </compilerArgs>
                 </configuration>
             </plugin>
 

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExample.java
@@ -22,10 +22,10 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KGroupedStream;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Materialized;
-import org.apache.kafka.streams.kstream.Serialized;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.state.HostInfo;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -33,6 +33,7 @@ import org.apache.kafka.streams.state.WindowStore;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -220,7 +221,7 @@ public class WordCountInteractiveQueriesExample {
 
     final KGroupedStream<String, String> groupedByWord = textLines
         .flatMapValues(value -> Arrays.asList(value.toLowerCase().split("\\W+")))
-        .groupBy((key, word) -> word, Serialized.with(stringSerde, stringSerde));
+        .groupBy((key, word) -> word, Grouped.with(stringSerde, stringSerde));
 
     // Create a State Store for with the all time word count
     groupedByWord.count(Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>as("word-count")
@@ -228,7 +229,7 @@ public class WordCountInteractiveQueriesExample {
 
     // Create a Windowed State Store that contains the word count for every
     // 1 minute
-    groupedByWord.windowedBy(TimeWindows.of(60000))
+    groupedByWord.windowedBy(TimeWindows.of(Duration.ofMinutes(1)))
         .count(Materialized.<String, Long, WindowStore<Bytes, byte[]>>as("windowed-word-count")
             .withValueSerde(Serdes.Long()));
 

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesRestService.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesRestService.java
@@ -43,6 +43,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -164,7 +165,7 @@ public class WordCountInteractiveQueriesRestService {
     }
 
     // fetch the window results for the given key and time range
-    final WindowStoreIterator<Long> results = store.fetch(key, from, to);
+    final WindowStoreIterator<Long> results = store.fetch(key, Instant.ofEpochMilli(from), Instant.ofEpochMilli(to));
 
     final List<KeyValueBean> windowResults = new ArrayList<>();
     while (results.hasNext()) {

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExample.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExample.java
@@ -31,11 +31,11 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.Joined;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
-import org.apache.kafka.streams.kstream.Serialized;
 import org.apache.kafka.streams.state.HostInfo;
 import org.apache.kafka.streams.state.KeyValueStore;
 
@@ -323,7 +323,7 @@ public class KafkaMusicExample {
 
     // create a state store to track song play counts
     final KTable<Song, Long> songPlayCounts = songPlays.groupBy((songId, song) -> song,
-                                                                Serialized.with(keySongSerde, valueSongSerde))
+                                                                Grouped.with(keySongSerde, valueSongSerde))
             .count(Materialized.<Song, Long, KeyValueStore<Bytes, byte[]>>as(SONG_PLAY_COUNT_STORE)
                            .withKeySerde(valueSongSerde)
                            .withValueSerde(Serdes.Long()));
@@ -337,7 +337,7 @@ public class KafkaMusicExample {
     songPlayCounts.groupBy((song, plays) ->
             KeyValue.pair(song.getGenre().toLowerCase(),
                 new SongPlayCount(song.getId(), plays)),
-        Serialized.with(Serdes.String(), songPlayCountSerde))
+        Grouped.with(Serdes.String(), songPlayCountSerde))
         // aggregate into a TopFiveSongs instance that will keep track
         // of the current top five for each genre. The data will be available in the
         // top-five-songs-genre store
@@ -361,7 +361,7 @@ public class KafkaMusicExample {
     songPlayCounts.groupBy((song, plays) ->
             KeyValue.pair(TOP_FIVE_KEY,
                 new SongPlayCount(song.getId(), plays)),
-        Serialized.with(Serdes.String(), songPlayCountSerde))
+        Grouped.with(Serdes.String(), songPlayCountSerde))
         .aggregate(TopFiveSongs::new,
             (aggKey, value, aggregate) -> {
               aggregate.add(value);

--- a/src/main/java/io/confluent/examples/streams/microservices/domain/Schemas.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/domain/Schemas.java
@@ -58,7 +58,7 @@ public class Schemas {
 
   public static class Topics {
 
-    public static final Map<String, Topic> ALL = new HashMap<>();
+    public static final Map<String, Topic<?, ?>> ALL = new HashMap<>();
     public static Topic<String, Order> ORDERS;
     public static Topic<String, OrderEnriched> ORDERS_ENRICHED;
     public static Topic<String, Payment> PAYMENTS;
@@ -85,7 +85,7 @@ public class Schemas {
 
   public static void configureSerdesWithSchemaRegistryUrl(final String url) {
     Topics.createTopics(); //wipe cached schema registry
-    for (final Topic topic : Topics.ALL.values()) {
+    for (final Topic<?, ?> topic : Topics.ALL.values()) {
       configure(topic.keySerde(), url);
       configure(topic.valueSerde(), url);
     }
@@ -93,7 +93,7 @@ public class Schemas {
     schemaRegistryUrl = url;
   }
 
-  private static void configure(final Serde serde, final String url) {
+  private static void configure(final Serde<?> serde, final String url) {
     if (serde instanceof SpecificAvroSerde) {
       serde.configure(Collections.singletonMap(SCHEMA_REGISTRY_URL_CONFIG, url), false);
     }

--- a/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
+++ b/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
@@ -15,6 +15,7 @@
  */
 package io.confluent.examples.streams
 
+import java.time.Duration
 import java.util.Properties
 import java.util.concurrent.TimeUnit
 
@@ -127,7 +128,7 @@ object MapFunctionScalaExample extends App {
   streams.start()
 
   sys.ShutdownHookThread {
-    streams.close(10, TimeUnit.SECONDS)
+    streams.close(Duration.ofSeconds(10))
   }
 
 }

--- a/src/main/scala/io/confluent/examples/streams/WordCountScalaExample.scala
+++ b/src/main/scala/io/confluent/examples/streams/WordCountScalaExample.scala
@@ -1,8 +1,10 @@
 package io.confluent.examples.streams
 
+import java.time.Duration
 import java.util.Properties
 import java.util.concurrent.TimeUnit
 
+import io.confluent.examples.streams.MapFunctionScalaExample.streams
 import org.apache.kafka.streams.scala.StreamsBuilder
 import org.apache.kafka.streams.scala.kstream._
 import org.apache.kafka.streams.{KafkaStreams, StreamsConfig}
@@ -128,7 +130,7 @@ object WordCountScalaExample extends App {
 
   // Add shutdown hook to respond to SIGTERM and gracefully close Kafka Streams
   sys.ShutdownHookThread {
-    streams.close(10, TimeUnit.SECONDS)
+    streams.close(Duration.ofSeconds(10))
   }
 
 }

--- a/src/test/java/io/confluent/examples/streams/ApplicationResetIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/ApplicationResetIntegrationTest.java
@@ -16,8 +16,9 @@
 package io.confluent.examples.streams;
 
 import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
-import kafka.admin.AdminClient;
 import kafka.tools.StreamsResetter;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
@@ -36,9 +37,11 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
+import static org.apache.kafka.clients.admin.AdminClient.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ApplicationResetIntegrationTest {
@@ -110,8 +113,10 @@ public class ApplicationResetIntegrationTest {
     //
 
     // wait for application to be completely shut down
-    final AdminClient adminClient = AdminClient.createSimplePlaintext(CLUSTER.bootstrapServers());
-    while (!adminClient.describeConsumerGroup(applicationId, 0).consumers().get().isEmpty()) {
+    final Properties config = new Properties();
+    config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+    final AdminClient adminClient = AdminClient.create(config);
+    while (!adminClient.describeConsumerGroups(Collections.singleton(applicationId)).all().get().get(applicationId).members().isEmpty()) {
       Utils.sleep(50);
     }
 
@@ -126,7 +131,7 @@ public class ApplicationResetIntegrationTest {
     Assert.assertEquals(0, exitCode);
 
     // wait for reset client to be completely closed
-    while (!adminClient.describeConsumerGroup(applicationId, 0).consumers().get().isEmpty()) {
+    while (!adminClient.describeConsumerGroups(Collections.singleton(applicationId)).all().get().get(applicationId).members().isEmpty()) {
       Utils.sleep(50);
     }
 

--- a/src/test/java/io/confluent/examples/streams/ApplicationResetIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/ApplicationResetIntegrationTest.java
@@ -41,7 +41,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
-import static org.apache.kafka.clients.admin.AdminClient.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ApplicationResetIntegrationTest {

--- a/src/test/java/io/confluent/examples/streams/GlobalKTablesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/GlobalKTablesExampleTest.java
@@ -64,9 +64,9 @@ public class GlobalKTablesExampleTest {
 
   @BeforeClass
   public static void createTopics() {
-    CLUSTER.createTopic(ORDER_TOPIC, 4, 1);
-    CLUSTER.createTopic(CUSTOMER_TOPIC, 3, 1);
-    CLUSTER.createTopic(PRODUCT_TOPIC, 2, 1);
+    CLUSTER.createTopic(ORDER_TOPIC, 4, (short) 1);
+    CLUSTER.createTopic(CUSTOMER_TOPIC, 3, (short) 1);
+    CLUSTER.createTopic(PRODUCT_TOPIC, 2, (short) 1);
     CLUSTER.createTopic(ENRICHED_ORDER_TOPIC);
   }
 

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
@@ -93,13 +93,13 @@ public class WordCountInteractiveQueriesExampleTest {
 
   @BeforeClass
   public static void createTopicsAndProduceDataToInputTopics() throws Exception {
-    CLUSTER.createTopic(WordCountInteractiveQueriesExample.TEXT_LINES_TOPIC, 2, 1);
+    CLUSTER.createTopic(WordCountInteractiveQueriesExample.TEXT_LINES_TOPIC, 2, (short) 1);
     // The next two topics don't need to be created as they would be auto-created
     // by Kafka Streams, but it just makes the test more reliable if they already exist
     // as creating the topics causes a rebalance which closes the stores etc. So it makes
     // the timing quite difficult...
-    CLUSTER.createTopic(WORD_COUNT, 2, 1);
-    CLUSTER.createTopic(WINDOWED_WORD_COUNT, 2, 1);
+    CLUSTER.createTopic(WORD_COUNT, 2, (short) 1);
+    CLUSTER.createTopic(WINDOWED_WORD_COUNT, 2, (short) 1);
   
     // Produce sample data to the input topic before the tests starts.
     final Properties producerConfig = new Properties();

--- a/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
+++ b/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
@@ -139,8 +139,8 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
         if (schemaRegistry != null) {
           schemaRegistry.stop();
         }
-      } catch (final Exception e) {
-        throw new RuntimeException(e);
+      } catch (final Exception fatal) {
+        throw new RuntimeException(fatal);
       }
       if (broker != null) {
         broker.stop();
@@ -149,8 +149,8 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
         if (zookeeper != null) {
           zookeeper.stop();
         }
-      } catch (final IOException e) {
-        throw new RuntimeException(e);
+      } catch (final IOException fatal) {
+        throw new RuntimeException(fatal);
       }
     } finally {
       running = false;
@@ -231,8 +231,8 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     for (final String topic : topics) {
       try {
         broker.deleteTopic(topic);
-      } catch (final UnknownTopicOrPartitionException e) {
-        // indicates success
+      } catch (final UnknownTopicOrPartitionException expected) {
+        // indicates (idempotent) success
       }
     }
 
@@ -261,8 +261,8 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
       try (final AdminClient adminClient = AdminClient.create(properties)) {
         final ListTopicsResult listTopicsResult = adminClient.listTopics();
         allTopics = listTopicsResult.names().get();
-      } catch (final InterruptedException | ExecutionException e) {
-        throw new RuntimeException(e);
+      } catch (final InterruptedException | ExecutionException fatal) {
+        throw new RuntimeException(fatal);
       }
       return !allTopics.removeAll(deletedTopics);
     }

--- a/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
+++ b/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
@@ -20,9 +20,10 @@ import io.confluent.kafka.schemaregistry.RestApp;
 import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import kafka.server.KafkaConfig$;
-import kafka.utils.ZkUtils;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
-import org.apache.kafka.common.security.JaasUtils;
 import org.apache.kafka.test.TestCondition;
 import org.apache.kafka.test.TestUtils;
 import org.junit.rules.ExternalResource;
@@ -32,8 +33,10 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Runs an in-memory, "embedded" Kafka cluster with 1 ZooKeeper instance, 1 Kafka broker, and 1
@@ -51,7 +54,6 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
   private static final String KAFKASTORE_INIT_TIMEOUT = "90000";
 
   private ZooKeeperEmbedded zookeeper;
-  private ZkUtils zkUtils = null;
   private KafkaEmbedded broker;
   private RestApp schemaRegistry;
   private final Properties brokerConfig;
@@ -83,18 +85,12 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     zookeeper = new ZooKeeperEmbedded();
     log.debug("ZooKeeper instance is running at {}", zookeeper.connectString());
 
-    zkUtils = ZkUtils.apply(
-        zookeeper.connectString(),
-        30000,
-        30000,
-        JaasUtils.isZkSecurityEnabled());
-
     final Properties effectiveBrokerConfig = effectiveBrokerConfigFrom(brokerConfig, zookeeper);
     log.debug("Starting a Kafka instance on port {} ...",
-        effectiveBrokerConfig.getProperty(KafkaConfig$.MODULE$.PortProp()));
+      effectiveBrokerConfig.getProperty(KafkaConfig$.MODULE$.PortProp()));
     broker = new KafkaEmbedded(effectiveBrokerConfig);
     log.debug("Kafka instance is running at {}, connected to ZooKeeper at {}",
-        broker.brokerList(), broker.zookeeperConnect());
+      broker.brokerList(), broker.zookeeperConnect());
 
     final Properties schemaRegistryProps = new Properties();
 
@@ -164,7 +160,7 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
 
   /**
    * This cluster's `bootstrap.servers` value.  Example: `127.0.0.1:9092`.
-   *
+   * <p>
    * You can use this to tell Kafka Streams applications, Kafka producers, and Kafka consumers (new
    * consumer API) how to connect to this cluster.
    */
@@ -175,7 +171,7 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
   /**
    * This cluster's ZK connection string aka `zookeeper.connect` in `hostnameOrIp:port` format.
    * Example: `127.0.0.1:2181`.
-   *
+   * <p>
    * You can use this to e.g. tell Kafka consumers (old consumer API) how to connect to this
    * cluster.
    */
@@ -196,7 +192,7 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
    * @param topic The name of the topic.
    */
   public void createTopic(final String topic) {
-    createTopic(topic, 1, 1, new Properties());
+    createTopic(topic, 1, (short) 1, Collections.emptyMap());
   }
 
   /**
@@ -206,8 +202,8 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
    * @param partitions  The number of partitions for this topic.
    * @param replication The replication factor for (the partitions of) this topic.
    */
-  public void createTopic(final String topic, final int partitions, final int replication) {
-    createTopic(topic, partitions, replication, new Properties());
+  public void createTopic(final String topic, final int partitions, final short replication) {
+    createTopic(topic, partitions, replication, Collections.emptyMap());
   }
 
   /**
@@ -220,8 +216,8 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
    */
   public void createTopic(final String topic,
                           final int partitions,
-                          final int replication,
-                          final Properties topicConfig) {
+                          final short replication,
+                          final Map<String, String> topicConfig) {
     broker.createTopic(topic, partitions, replication, topicConfig);
   }
 
@@ -229,13 +225,15 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
    * Deletes multiple topics and blocks until all topics got deleted.
    *
    * @param timeoutMs the max time to wait for the topics to be deleted (does not block if {@code <= 0})
-   * @param topics the name of the topics
+   * @param topics    the name of the topics
    */
   public void deleteTopicsAndWait(final long timeoutMs, final String... topics) throws InterruptedException {
     for (final String topic : topics) {
       try {
         broker.deleteTopic(topic);
-      } catch (final UnknownTopicOrPartitionException e) { }
+      } catch (final UnknownTopicOrPartitionException e) {
+        // indicates success
+      }
     }
 
     if (timeoutMs > 0) {
@@ -256,7 +254,16 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
 
     @Override
     public boolean conditionMet() {
-      final Set<String> allTopics = new HashSet<>(scala.collection.JavaConversions.seqAsJavaList(zkUtils.getAllTopics()));
+      final Properties properties = new Properties();
+      properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
+      final Set<String> allTopics;
+
+      try (final AdminClient adminClient = AdminClient.create(properties)) {
+        final ListTopicsResult listTopicsResult = adminClient.listTopics();
+        allTopics = listTopicsResult.names().get();
+      } catch (final InterruptedException | ExecutionException e) {
+        throw new RuntimeException(e);
+      }
       return !allTopics.removeAll(deletedTopics);
     }
   }

--- a/src/test/java/io/confluent/examples/streams/kafka/KafkaEmbedded.java
+++ b/src/test/java/io/confluent/examples/streams/kafka/KafkaEmbedded.java
@@ -15,16 +15,13 @@
  */
 package io.confluent.examples.streams.kafka;
 
-import kafka.admin.AdminUtils;
-import kafka.admin.RackAwareMode;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaConfig$;
 import kafka.server.KafkaServer;
 import kafka.utils.TestUtils;
-import kafka.utils.ZKStringSerializer$;
-import kafka.utils.ZkUtils;
-import org.I0Itec.zkclient.ZkClient;
-import org.I0Itec.zkclient.ZkConnection;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.Time;
@@ -34,7 +31,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Runs an in-memory, "embedded" instance of a Kafka broker, which listens at `127.0.0.1:9092` by
@@ -49,8 +49,6 @@ public class KafkaEmbedded {
   private static final Logger log = LoggerFactory.getLogger(KafkaEmbedded.class);
 
   private static final String DEFAULT_ZK_CONNECT = "127.0.0.1:2181";
-  private static final int DEFAULT_ZK_SESSION_TIMEOUT_MS = 10 * 1000;
-  private static final int DEFAULT_ZK_CONNECTION_TIMEOUT_MS = 8 * 1000;
 
   private final Properties effectiveConfig;
   private final File logDir;
@@ -132,7 +130,7 @@ public class KafkaEmbedded {
    * @param topic The name of the topic.
    */
   public void createTopic(final String topic) {
-    createTopic(topic, 1, 1, new Properties());
+    createTopic(topic, 1, (short) 1, Collections.emptyMap());
   }
 
   /**
@@ -142,8 +140,8 @@ public class KafkaEmbedded {
    * @param partitions  The number of partitions for this topic.
    * @param replication The replication factor for (the partitions of) this topic.
    */
-  public void createTopic(final String topic, final int partitions, final int replication) {
-    createTopic(topic, partitions, replication, new Properties());
+  public void createTopic(final String topic, final int partitions, final short replication) {
+    createTopic(topic, partitions, replication, Collections.emptyMap());
   }
 
   /**
@@ -156,23 +154,22 @@ public class KafkaEmbedded {
    */
   public void createTopic(final String topic,
                           final int partitions,
-                          final int replication,
-                          final Properties topicConfig) {
+                          final short replication,
+                          final Map<String, String> topicConfig) {
     log.debug("Creating topic { name: {}, partitions: {}, replication: {}, config: {} }",
-        topic, partitions, replication, topicConfig);
-    // Note: You must initialize the ZkClient with ZKStringSerializer.  If you don't, then
-    // createTopic() will only seem to work (it will return without error).  The topic will exist in
-    // only ZooKeeper and will be returned when listing topics, but Kafka itself does not create the
-    // topic.
-    final ZkClient zkClient = new ZkClient(
-        zookeeperConnect(),
-        DEFAULT_ZK_SESSION_TIMEOUT_MS,
-        DEFAULT_ZK_CONNECTION_TIMEOUT_MS,
-        ZKStringSerializer$.MODULE$);
-    final boolean isSecure = false;
-    final ZkUtils zkUtils = new ZkUtils(zkClient, new ZkConnection(zookeeperConnect()), isSecure);
-    AdminUtils.createTopic(zkUtils, topic, partitions, replication, topicConfig, RackAwareMode.Enforced$.MODULE$);
-    zkClient.close();
+      topic, partitions, replication, topicConfig);
+
+    final Properties properties = new Properties();
+    properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList());
+
+    try (final AdminClient adminClient = AdminClient.create(properties)) {
+      final NewTopic newTopic = new NewTopic(topic, partitions, replication);
+      newTopic.configs(topicConfig);
+      adminClient.createTopics(Collections.singleton(newTopic)).all().get();
+    } catch (final InterruptedException | ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+
   }
 
   /**
@@ -182,14 +179,13 @@ public class KafkaEmbedded {
    */
   public void deleteTopic(final String topic) {
     log.debug("Deleting topic {}", topic);
-    final ZkClient zkClient = new ZkClient(
-        zookeeperConnect(),
-        DEFAULT_ZK_SESSION_TIMEOUT_MS,
-        DEFAULT_ZK_CONNECTION_TIMEOUT_MS,
-        ZKStringSerializer$.MODULE$);
-    final boolean isSecure = false;
-    final ZkUtils zkUtils = new ZkUtils(zkClient, new ZkConnection(zookeeperConnect()), isSecure);
-    AdminUtils.deleteTopic(zkUtils, topic);
-    zkClient.close();
+    final Properties properties = new Properties();
+    properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList());
+
+    try (final AdminClient adminClient = AdminClient.create(properties)) {
+      adminClient.deleteTopics(Collections.singleton(topic)).all().get();
+    } catch (final InterruptedException | ExecutionException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src/test/java/io/confluent/examples/streams/kafka/KafkaEmbedded.java
+++ b/src/test/java/io/confluent/examples/streams/kafka/KafkaEmbedded.java
@@ -167,8 +167,8 @@ public class KafkaEmbedded {
       final NewTopic newTopic = new NewTopic(topic, partitions, replication);
       newTopic.configs(topicConfig);
       adminClient.createTopics(Collections.singleton(newTopic)).all().get();
-    } catch (final InterruptedException | ExecutionException e) {
-      throw new RuntimeException(e);
+    } catch (final InterruptedException | ExecutionException fatal) {
+      throw new RuntimeException(fatal);
     }
 
   }

--- a/src/test/java/io/confluent/examples/streams/kafka/KafkaEmbedded.java
+++ b/src/test/java/io/confluent/examples/streams/kafka/KafkaEmbedded.java
@@ -22,6 +22,7 @@ import kafka.utils.TestUtils;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.Time;
@@ -184,8 +185,12 @@ public class KafkaEmbedded {
 
     try (final AdminClient adminClient = AdminClient.create(properties)) {
       adminClient.deleteTopics(Collections.singleton(topic)).all().get();
-    } catch (final InterruptedException | ExecutionException e) {
+    } catch (final InterruptedException e) {
       throw new RuntimeException(e);
+    } catch (final ExecutionException e) {
+      if (!(e.getCause() instanceof UnknownTopicOrPartitionException)) {
+        throw new RuntimeException(e);
+      }
     }
   }
 }


### PR DESCRIPTION
Setting fail-on-warn and resolving all warnings in one PR turned out to be too large a change, and also hard to debug (see https://github.com/confluentinc/kafka-streams-examples/pull/201).

Instead, this change just enables the warnings, and then resolves some of the warnings.

We can follow up by tackling more warnings in another PR.