### PR TITLE
MINOR: Retry topic creation after a race condition to delete then create

### DIFF
--- a/src/test/java/io/confluent/examples/streams/microservices/OrdersServiceTest.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/OrdersServiceTest.java
@@ -9,6 +9,7 @@ import io.confluent.examples.streams.microservices.domain.beans.OrderBean;
 import io.confluent.examples.streams.microservices.util.MicroserviceTestUtils;
 import io.confluent.examples.streams.microservices.util.Paths;
 
+import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -56,7 +57,12 @@ public class OrdersServiceTest extends MicroserviceTestUtils {
   @Before
   public void prepareKafkaCluster() throws Exception {
     CLUSTER.deleteTopicsAndWait(30000, Topics.ORDERS.name(), "OrdersService-orders-store-changelog");
-    CLUSTER.createTopic(Topics.ORDERS.name());
+    try {
+      CLUSTER.createTopic(Topics.ORDERS.name());
+    } catch (TopicExistsException tex) {
+      log.warn("Received a TopicExistsException after an alleged successful deletion, will retry");
+      CLUSTER.createTopic(Topics.ORDERS.name());
+    }
     Schemas.configureSerdesWithSchemaRegistryUrl(CLUSTER.schemaRegistryUrl());
   }
 

--- a/src/test/java/io/confluent/examples/streams/microservices/OrdersServiceTest.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/OrdersServiceTest.java
@@ -59,7 +59,7 @@ public class OrdersServiceTest extends MicroserviceTestUtils {
     CLUSTER.deleteTopicsAndWait(30000, Topics.ORDERS.name(), "OrdersService-orders-store-changelog");
     try {
       CLUSTER.createTopic(Topics.ORDERS.name());
-    } catch (TopicExistsException tex) {
+    } catch (final TopicExistsException tex) {
       log.warn("Received a TopicExistsException after an alleged successful deletion, will retry");
       CLUSTER.createTopic(Topics.ORDERS.name());
     }

--- a/src/test/java/io/confluent/examples/streams/microservices/util/MicroserviceTestUtils.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/util/MicroserviceTestUtils.java
@@ -38,7 +38,7 @@ import static java.util.Collections.singletonList;
 
 public class MicroserviceTestUtils {
 
-  private static final Logger log = LoggerFactory.getLogger(MicroserviceTestUtils.class);
+  protected static final Logger log = LoggerFactory.getLogger(MicroserviceTestUtils.class);
   private static final List<TopicTailer> tailers = new ArrayList<>();
   private static int consumerCounter;
 


### PR DESCRIPTION
From looking at the test logs, it looks like there can be a race condition from when the topic deletion is completed and the request to create the topic `orders`
This line errors out because the topic exists
```
[2019-03-05 15:25:40,982] INFO [kafka-request-handler-1] [Admin Manager on Broker 0]: Error processing create topic request for topic orders with arguments (numPartitions=1, replicationFactor=1, replicasAssignments={}, configs={}) (kafka.server.AdminManager)
org.apache.kafka.common.errors.TopicExistsException: Topic 'orders' already exists.
```
However on the very next line we can see the deletion completes successfully
```
[2019-03-05 15:25:41,010] INFO [controller-event-thread] [Topic Deletion Manager 0], Deletion of topic orders successfully completed (kafka.controller.TopicDeletionManager)
```

So I propose if we get an `TopicExistsException` we re-try once to account for this race condition.