### PR TITLE
MINOR: Need to use ZK client on broker to confirm topics deleted

### DIFF
--- a/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
+++ b/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
@@ -250,6 +250,7 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
 
     @Override
     public boolean conditionMet() {
+      //TODO once KAFKA-6098 is fixed use AdminClient to verify topics have been deleted
       final Set<String> allTopics = new HashSet<>(
           JavaConverters.seqAsJavaListConverter(broker.kafkaServer().zkClient().getAllTopicsInCluster()).asJava());
       return !allTopics.removeAll(deletedTopics);

--- a/src/test/java/io/confluent/examples/streams/kafka/KafkaEmbedded.java
+++ b/src/test/java/io/confluent/examples/streams/kafka/KafkaEmbedded.java
@@ -193,4 +193,8 @@ public class KafkaEmbedded {
       }
     }
   }
+
+  KafkaServer kafkaServer() {
+    return kafka;
+  }
 }


### PR DESCRIPTION
We've recently started seeing errors in the examples test due to race condition when using the `AdminClient` to confirm if a topic has been deleted.

The failure shows up in the logs with the failure to create the topic as it still exists as the test condition returned `true`
```
[2019-03-06 01:55:15,914] INFO [data-plane-kafka-request-handler-0] [Admin Manager on Broker 0]: Error processing create topic request for topic orders with arguments (numPartitions=1, replicationFactor=1, replicasAssignments={}, configs={}) (kafka.server.AdminManager)
org.apache.kafka.common.errors.TopicExistsException: Topic 'orders' already exists.
```
And a little later in the log we see the actual deletion taking place
```
[2019-03-06 01:55:15,941] INFO [controller-event-thread] [Topic Deletion Manager 0], Deletion of topic orders successfully completed (kafka.controller.TopicDeletionManager)
```
This PR uses the `KafkaEmbedded` `zk` client to check for topic deletion in the test condition.