### PR TITLE
Enable SR fix for 3.3.x branches (do not merged to 4.x or newer)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,8 +222,9 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry</artifactId>
-            <version>${confluent.version}</version>
-            <!-- Required for e.g. schema registry's RestApp -->
+            <!-- we explicitly depend on 3.3.2 here because it contains a bug fix
+                 that we want for EmbeddedSingleNodeKafkaCluster class -->
+            <version>3.3.2</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
@@ -283,7 +283,6 @@ public class KafkaMusicExampleTest {
             genreChartRequest,
             new GenericType<List<SongPlayCountBean>>() {},
             0);
-        System.err.println(chart.size());
         return chart.size() == 5;
       } catch (Exception e) {
         e.printStackTrace();


### PR DESCRIPTION
3.3.2 was release a while ago. This PR applies a fix as described in the comment.

This PR is for 3.3.0 and 3.3.1 -- in 3.3.2 and newer we can change the `pom.xml` dependency back to `${confluent.version}`.

This fix does not go into 4.x or newer branches as describe in the comment.