### PR TITLE
Remove redundant groupId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,6 @@
         <version>3.3.0</version>
     </parent>
 
-    <groupId>io.confluent</groupId>
     <artifactId>kafka-streams-examples</artifactId>
     <packaging>jar</packaging>
 


### PR DESCRIPTION
`groupId` is inherited from parent pom