### PR TITLE
Fix SR version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,9 +221,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry</artifactId>
-            <!-- we explicitly depend on 3.3.2 here because it contains a bug fix
-                 that we want for EmbeddedSingleNodeKafkaCluster class -->
-            <version>3.3.2</version>
+            <version>${confluent.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Follow up to #213: set SR version to current version

The fix from #213 was only required for 3.3.0 and 3.3.1 to get newer SR version 3.3.2 that contains a fix we depend on.