### PR TITLE
MINOR: Use checkstyle version from common pom which is newer and makes keeping this repo up to date easier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,13 +444,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>8.12</version> <!-- bumping to latest checkstyle version -->
-                    </dependency>
-                </dependencies>
                 <executions>
                     <!--
                      This declaration merges with the one in the parent, rather


### PR DESCRIPTION
This is easier to manage centrally to make sure updates are applied everywhere and checkstyle in particular doesn't tend to cause many problems when updated centrally.