### PR TITLE
README Link pointing to removed file

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Additional examples may be found under [src/test/](src/test/java/io/confluent/ex
 
 > Tip: Run `mvn test` to launch the tests.
 
-| Integration Test Name               | Concepts used                               | Java 8+ | Java 7+ | Scala |
+| Test Name                           | Concepts used                               | Java 8+ | Java 7+ | Scala |
 | ----------------------------------- | ------------------------------------------- | ------- | ------- | ----- |
-| WordCount                           | DSL, aggregation, stateful                  | [Java 8+ Example](src/test/java/io/confluent/examples/streams/WordCountLambdaIntegrationTest.java) | | [Scala Example](src/test/scala/io/confluent/examples/streams/WordCountScalaIntegrationTest.scala) |
+| WordCount                           | DSL, aggregation, stateful                  | [Java 8+ Example](src/test/java/io/confluent/examples/streams/WordCountLambdaExampleTest.java) | | [Scala Example](src/test/scala/io/confluent/examples/streams/WordCountScalaIntegrationTest.scala) |
 | WordCountInteractiveQueries         | Interactive Queries, REST, RPC              | | [Java 7+ Example](src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java) | |
 | CustomStreamTableJoin               | DSL, Processor API, Transformers            | [Java 8+ Example](src/test/java/io/confluent/examples/streams/CustomStreamTableJoinIntegrationTest.java) | | |
 | EventDeduplication                  | DSL, Processor API, Transformers            | [Java 8+ Example](src/test/java/io/confluent/examples/streams/EventDeduplicationLambdaIntegrationTest.java) | | |


### PR DESCRIPTION
In #219 WordCountLambdaIntegrationTest.java was replaced by WordCountLambdaExampleTest.java.

Merging of #219 and README improvements has caused test Table is pointing to non existing file

I also change header title from "Integration Test Name" -> "Test Name"

I am not sure should what these Concepts used now in this test table should refer.
Concept used in Test class or actual implementation class?