### PR TITLE
MINOR: port more tests to TopologyTestDriver

### DIFF
--- a/src/main/scala/io/confluent/examples/streams/algebird/ProbabilisticCounter.scala
+++ b/src/main/scala/io/confluent/examples/streams/algebird/ProbabilisticCounter.scala
@@ -9,7 +9,7 @@ import org.apache.kafka.streams.processor.ProcessorContext
   * estimate.
   */
 class ProbabilisticCounter(val cmsStoreName: String)
-    extends Transformer[Array[Byte], String, KeyValue[String, Long]] {
+    extends Transformer[String, String, KeyValue[String, Long]] {
 
   private var cmsState: CMSStore[String] = _
   private var processorContext: ProcessorContext = _
@@ -19,7 +19,7 @@ class ProbabilisticCounter(val cmsStoreName: String)
     cmsState = this.processorContext.getStateStore(cmsStoreName).asInstanceOf[CMSStore[String]]
   }
 
-  override def transform(key: Array[Byte], value: String): KeyValue[String, Long] = {
+  override def transform(key: String, value: String): KeyValue[String, Long] = {
     // Count the record value, think: "+ 1"
     cmsState.put(value, this.processorContext.timestamp())
 

--- a/src/test/java/io/confluent/examples/streams/EventDeduplicationLambdaIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/EventDeduplicationLambdaIntegrationTest.java
@@ -15,18 +15,13 @@
  */
 package io.confluent.examples.streams;
 
-import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.kstream.Transformer;
@@ -36,8 +31,6 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.test.TestUtils;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -45,56 +38,45 @@ import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * End-to-end integration test that demonstrates how to remove duplicate records from an input
  * stream.
- *
+ * <p>
  * Here, a stateful {@link org.apache.kafka.streams.kstream.Transformer} (from the Processor API)
  * detects and discards duplicate input records based on an "event id" that is embedded in each
  * input record.  This transformer is then included in a topology defined via the DSL.
- *
+ * <p>
  * In this simplified example, the values of input records represent the event ID by which
  * duplicates will be detected.  In practice, record values would typically be a more complex data
  * structure, with perhaps one of the fields being such an event ID.  De-duplication by an event ID
  * is but one example of how to perform de-duplication in general.  The code example below can be
  * adapted to other de-duplication approaches.
- *
+ * <p>
  * IMPORTANT:  Kafka including its Streams API support exactly-once semantics since version 0.11.
  * With this feature available, most use cases will no longer need to worry about duplicate messages
  * or duplicate processing.  That said, there will still be some use cases where you have your own
  * business rules that define when two events are considered to be "the same" and need to be
  * de-duplicated (e.g. two events having the same payload but different timestamps).  The example
  * below demonstrates how to implement your own business rules for event de-duplication.
- *
+ * <p>
  * Note: This example uses lambda expressions and thus works with Java 8+ only.
  */
 public class EventDeduplicationLambdaIntegrationTest {
 
-  @ClassRule
-  public static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster();
-
-  private static String inputTopic = "inputTopic";
-  private static String outputTopic = "outputTopic";
-
-  private static String storeName = "eventId-store";
-
-  @BeforeClass
-  public static void startKafkaCluster() throws Exception {
-    CLUSTER.createTopic(inputTopic);
-    CLUSTER.createTopic(outputTopic);
-  }
+  private static final String storeName = "eventId-store";
 
   /**
    * Discards duplicate records from the input stream.
-   *
+   * <p>
    * Duplicate records are detected based on an event ID;  in this simplified example, the record
    * value is the event ID.  The transformer remembers known event IDs in an associated window state
    * store, which automatically purges/expires event IDs from the store after a certain amount of
    * time has passed to prevent the store from growing indefinitely.
-   *
+   * <p>
    * Note: This code is for demonstration purposes and was not tested for production usage.
    */
   private static class DeduplicationTransformer<K, V, E> implements Transformer<K, V, KeyValue<K, V>> {
@@ -118,9 +100,9 @@ public class EventDeduplicationLambdaIntegrationTest {
      *                                     ID), during the time of which any incoming duplicates of
      *                                     the event will be dropped, thereby de-duplicating the
      *                                     input.
-     * @param idExtractor extracts a unique identifier from a record by which we de-duplicate input
-     *                    records; if it returns null, the record will not be considered for
-     *                    de-duping but forwarded as-is.
+     * @param idExtractor                  extracts a unique identifier from a record by which we de-duplicate input
+     *                                     records; if it returns null, the record will not be considered for
+     *                                     de-duping but forwarded as-is.
      */
     DeduplicationTransformer(final long maintainDurationPerEventInMs, final KeyValueMapper<K, V, E> idExtractor) {
       if (maintainDurationPerEventInMs < 1) {
@@ -158,9 +140,9 @@ public class EventDeduplicationLambdaIntegrationTest {
     private boolean isDuplicate(final E eventId) {
       final long eventTime = context.timestamp();
       final WindowStoreIterator<Long> timeIterator = eventIdStore.fetch(
-          eventId,
-          eventTime - leftDurationMs,
-          eventTime + rightDurationMs);
+        eventId,
+        eventTime - leftDurationMs,
+        eventTime + rightDurationMs);
       final boolean isDuplicate = timeIterator.hasNext();
       timeIterator.close();
       return isDuplicate;
@@ -189,12 +171,12 @@ public class EventDeduplicationLambdaIntegrationTest {
   }
 
   @Test
-  public void shouldRemoveDuplicatesFromTheInput() throws Exception {
+  public void shouldRemoveDuplicatesFromTheInput() {
     final String firstId = UUID.randomUUID().toString(); // e.g. "4ff3cb44-abcb-46e3-8f9a-afb7cc74fbb8"
     final String secondId = UUID.randomUUID().toString();
     final String thirdId = UUID.randomUUID().toString();
     final List<String> inputValues = Arrays.asList(firstId, secondId, firstId, firstId, secondId, thirdId,
-        thirdId, firstId, secondId);
+      thirdId, firstId, secondId);
     final List<String> expectedValues = Arrays.asList(firstId, secondId, thirdId);
 
     //
@@ -204,13 +186,9 @@ public class EventDeduplicationLambdaIntegrationTest {
 
     final Properties streamsConfiguration = new Properties();
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "deduplication-lambda-integration-test");
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
     streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArray().getClass().getName());
     streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
-    // The commit interval for flushing records to state stores and downstream must be lower than
-    // this integration test's timeout (30 secs) to ensure we observe the expected processing results.
-    streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, TimeUnit.SECONDS.toMillis(10));
-    streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     // Use a temporary directory for storing state, which will be automatically removed after the test.
     streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
 
@@ -232,54 +210,57 @@ public class EventDeduplicationLambdaIntegrationTest {
     final long retentionPeriod = maintainDurationPerEventInMs;
 
     final StoreBuilder<WindowStore<String, Long>> dedupStoreBuilder = Stores.windowStoreBuilder(
-            Stores.persistentWindowStore(storeName,
-                                         retentionPeriod,
-                                         numberOfSegments,
-                                         maintainDurationPerEventInMs,
-                                         false
-            ),
-            Serdes.String(),
-            Serdes.Long());
+      Stores.persistentWindowStore(storeName,
+        retentionPeriod,
+        numberOfSegments,
+        maintainDurationPerEventInMs,
+        false
+      ),
+      Serdes.String(),
+      Serdes.Long());
 
 
     builder.addStateStore(dedupStoreBuilder);
 
+    final String inputTopic = "inputTopic";
+    final String outputTopic = "outputTopic";
+
     final KStream<byte[], String> input = builder.stream(inputTopic);
     final KStream<byte[], String> deduplicated = input.transform(
-        // In this example, we assume that the record value as-is represents a unique event ID by
-        // which we can perform de-duplication.  If your records are different, adapt the extractor
-        // function as needed.
-        () -> new DeduplicationTransformer<>(maintainDurationPerEventInMs, (key, value) -> value),
-        storeName);
+      // In this example, we assume that the record value as-is represents a unique event ID by
+      // which we can perform de-duplication.  If your records are different, adapt the extractor
+      // function as needed.
+      () -> new DeduplicationTransformer<>(maintainDurationPerEventInMs, (key, value) -> value),
+      storeName);
     deduplicated.to(outputTopic);
 
-    final KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfiguration);
-    streams.start();
+    final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration);
 
-    //
-    // Step 2: Produce some input data to the input topic.
-    //
-    final Properties producerConfig = new Properties();
-    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
-    producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
-    producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-    IntegrationTestUtils.produceValuesSynchronously(inputTopic, inputValues, producerConfig);
+    try {
+      //
+      // Step 2: Produce some input data to the input topic.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        inputTopic,
+        inputValues.stream().map(v -> new KeyValue<>(null, v)).collect(Collectors.toList()),
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new StringSerializer()
+      );
 
-    //
-    // Step 3: Verify the application's output data.
-    //
-    final Properties consumerConfig = new Properties();
-    consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "deduplication-integration-test-standard-consumer");
-    consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-    consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-    consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    final List<String> actualValues = IntegrationTestUtils.waitUntilMinValuesRecordsReceived(consumerConfig,
-        outputTopic, expectedValues.size());
-    streams.close();
-    assertThat(actualValues).containsExactlyElementsOf(expectedValues);
+      //
+      // Step 3: Verify the application's output data.
+      //
+      final List<String> actualValues = IntegrationTestUtils.drainStreamOutput(
+        outputTopic,
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new StringDeserializer()
+      ).stream().map(kv -> kv.value).collect(Collectors.toList());
+      assertThat(actualValues).containsExactlyElementsOf(expectedValues);
+    } finally {
+      topologyTestDriver.close();
+    }
   }
 
 }

--- a/src/test/java/io/confluent/examples/streams/FanoutLambdaIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/FanoutLambdaIntegrationTest.java
@@ -15,20 +15,15 @@
  */
 package io.confluent.examples.streams;
 
-import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.KStream;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.apache.kafka.streams.kstream.ValueMapper;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -40,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * End-to-end integration test that demonstrates "fan-out", using an embedded Kafka cluster.
- *
+ * <p>
  * This example shows how you can read from one input topic/stream, transform the data (here:
  * trivially) in two different ways via two intermediate streams, and then write the respective
  * results to two output topics.
@@ -56,27 +51,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * }
  * </pre>
- *
+ * <p>
  * Note: This example uses lambda expressions and thus works with Java 8+ only.
  */
 public class FanoutLambdaIntegrationTest {
 
-  @ClassRule
-  public static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster();
-
-  private static String inputTopicA = "A";
-  private static String outputTopicB = "B";
-  private static String outputTopicC = "C";
-
-  @BeforeClass
-  public static void startKafkaCluster() {
-    CLUSTER.createTopic(inputTopicA);
-    CLUSTER.createTopic(outputTopicB);
-    CLUSTER.createTopic(outputTopicC);
-  }
-
   @Test
-  public void shouldFanoutTheInput() throws Exception {
+  public void shouldFanoutTheInput() {
     final List<String> inputValues = Arrays.asList("Hello", "World");
     final List<String> expectedValuesForB = inputValues.stream().map(String::toUpperCase).collect(Collectors.toList());
     final List<String> expectedValuesForC = inputValues.stream().map(String::toLowerCase).collect(Collectors.toList());
@@ -88,56 +69,56 @@ public class FanoutLambdaIntegrationTest {
 
     final Properties streamsConfiguration = new Properties();
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "fanout-lambda-integration-test");
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
     streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
-    streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
+    final String inputTopicA = "A";
+    final String outputTopicB = "B";
+    final String outputTopicC = "C";
     final KStream<byte[], String> stream1 = builder.stream(inputTopicA);
-    final KStream<byte[], String> stream2 = stream1.mapValues((v -> v.toUpperCase()));
-    final KStream<byte[], String> stream3 = stream1.mapValues(v -> v.toLowerCase());
+    final KStream<byte[], String> stream2 = stream1.mapValues(((ValueMapper<String, String>) String::toUpperCase));
+    final KStream<byte[], String> stream3 = stream1.mapValues((ValueMapper<String, String>) String::toLowerCase);
     stream2.to(outputTopicB);
     stream3.to(outputTopicC);
 
-    final KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfiguration);
-    streams.start();
+    final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration);
 
-    //
-    // Step 2: Produce some input data to the input topic.
-    //
-    final Properties producerConfig = new Properties();
-    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
-    producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
-    producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-    IntegrationTestUtils.produceValuesSynchronously(inputTopicA, inputValues, producerConfig);
+    try {
+      //
+      // Step 2: Produce some input data to the input topic.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        inputTopicA,
+        inputValues.stream().map(v -> new KeyValue<>(null, v)).collect(Collectors.toList()),
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new StringSerializer()
+      );
 
-    //
-    // Step 3: Verify the application's output data.
-    //
+      //
+      // Step 3: Verify the application's output data.
+      //
 
-    // Verify output topic B
-    final Properties consumerConfigB = new Properties();
-    consumerConfigB.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    consumerConfigB.put(ConsumerConfig.GROUP_ID_CONFIG, "fanout-lambda-integration-test-standard-consumer-topicB");
-    consumerConfigB.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-    consumerConfigB.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-    consumerConfigB.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    final List<String> actualValuesForB = IntegrationTestUtils.waitUntilMinValuesRecordsReceived(consumerConfigB,
-        outputTopicB, inputValues.size());
-    assertThat(actualValuesForB).isEqualTo(expectedValuesForB);
+      // Verify output topic B
+      final List<String> actualValuesForB = IntegrationTestUtils.drainStreamOutput(
+        outputTopicB,
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new StringDeserializer()
+      ).stream().map(kv -> kv.value).collect(Collectors.toList());
+      assertThat(actualValuesForB).isEqualTo(expectedValuesForB);
 
-    // Verify output topic C
-    final Properties consumerConfigC = new Properties();
-    consumerConfigC.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    consumerConfigC.put(ConsumerConfig.GROUP_ID_CONFIG, "fanout-lambda-integration-test-standard-consumer-topicC");
-    consumerConfigC.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-    consumerConfigC.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-    consumerConfigC.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    final List<String> actualValuesForC = IntegrationTestUtils.waitUntilMinValuesRecordsReceived(consumerConfigC,
-        outputTopicC, inputValues.size());
-    streams.close();
-    assertThat(actualValuesForC).isEqualTo(expectedValuesForC);
+      // Verify output topic C
+      final List<String> actualValuesForC = IntegrationTestUtils.drainStreamOutput(
+        outputTopicC,
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new StringDeserializer()
+      ).stream().map(kv -> kv.value).collect(Collectors.toList());
+      assertThat(actualValuesForC).isEqualTo(expectedValuesForC);
+    } finally {
+      topologyTestDriver.close();
+    }
   }
 
 }

--- a/src/test/java/io/confluent/examples/streams/FanoutLambdaIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/FanoutLambdaIntegrationTest.java
@@ -76,8 +76,8 @@ public class FanoutLambdaIntegrationTest {
     final String outputTopicB = "B";
     final String outputTopicC = "C";
     final KStream<byte[], String> stream1 = builder.stream(inputTopicA);
-    final KStream<byte[], String> stream2 = stream1.mapValues(((ValueMapper<String, String>) String::toUpperCase));
-    final KStream<byte[], String> stream3 = stream1.mapValues((ValueMapper<String, String>) String::toLowerCase);
+    final KStream<byte[], String> stream2 = stream1.mapValues(s -> s.toUpperCase());
+    final KStream<byte[], String> stream3 = stream1.mapValues(s -> s.toLowerCase());
     stream2.to(outputTopicB);
     stream3.to(outputTopicC);
 

--- a/src/test/java/io/confluent/examples/streams/HandlingCorruptedInputRecordsIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/HandlingCorruptedInputRecordsIntegrationTest.java
@@ -15,25 +15,18 @@
  */
 package io.confluent.examples.streams;
 
-import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.errors.SerializationException;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Produced;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -48,26 +41,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * End-to-end integration test that demonstrates how to handle corrupt input records (think: poison
  * pill messages) in a Kafka topic, which would normally lead to application failures due to
  * (de)serialization exceptions.
- *
+ * <p>
  * In this example we choose to ignore/skip corrupted input records.  We describe further options at
  * http://docs.confluent.io/current/streams/faq.html, e.g. sending corrupted records to a quarantine
  * topic (think: dead letter queue).
- *
+ * <p>
  * Note: This example uses lambda expressions and thus works with Java 8+ only.
  */
 public class HandlingCorruptedInputRecordsIntegrationTest {
-
-  @ClassRule
-  public static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster();
-
-  private static String inputTopic = "inputTopic";
-  private static String outputTopic = "outputTopic";
-
-  @BeforeClass
-  public static void startKafkaCluster() throws Exception {
-    CLUSTER.createTopic(inputTopic);
-    CLUSTER.createTopic(outputTopic);
-  }
 
   @Test
   public void shouldIgnoreCorruptInputRecords() throws Exception {
@@ -81,79 +62,80 @@ public class HandlingCorruptedInputRecordsIntegrationTest {
 
     final Properties streamsConfiguration = new Properties();
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "failure-handling-integration-test");
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
     streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArray().getClass().getName());
     streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.ByteArray().getClass().getName());
-    streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
     final Serde<String> stringSerde = Serdes.String();
     final Serde<Long> longSerde = Serdes.Long();
+
+    final String inputTopic = "inputTopic";
+    final String outputTopic = "outputTopic";
 
     final KStream<byte[], byte[]> input = builder.stream(inputTopic);
 
     // Note how the returned stream is of type `KStream<String, Long>`.
     final KStream<String, Long> doubled = input.flatMap(
-        (k, v) -> {
-          try {
-            // Attempt deserialization
-            final String key = stringSerde.deserializer().deserialize("input-topic", k);
-            final long value = longSerde.deserializer().deserialize("input-topic", v);
+      (k, v) -> {
+        try {
+          // Attempt deserialization
+          final String key = stringSerde.deserializer().deserialize("input-topic", k);
+          final long value = longSerde.deserializer().deserialize("input-topic", v);
 
-            // Ok, the record is valid (not corrupted).  Let's take the
-            // opportunity to also process the record in some way so that
-            // we haven't paid the deserialization cost just for "poison pill"
-            // checking.
-            return Collections.singletonList(KeyValue.pair(key, 2 * value));
-          } catch (final SerializationException e) {
-            // Ignore/skip the corrupted record by catching the exception.
-            // Optionally, we can log the fact that we did so:
-            System.err.println("Could not deserialize record: " + e.getMessage());
-          }
-          return Collections.emptyList();
+          // Ok, the record is valid (not corrupted).  Let's take the
+          // opportunity to also process the record in some way so that
+          // we haven't paid the deserialization cost just for "poison pill"
+          // checking.
+          return Collections.singletonList(KeyValue.pair(key, 2 * value));
+        } catch (final SerializationException e) {
+          // Ignore/skip the corrupted record by catching the exception.
+          // Optionally, we can log the fact that we did so:
+          System.err.println("Could not deserialize record: " + e.getMessage());
         }
+        return Collections.emptyList();
+      }
     );
 
     // Write the processing results (which was generated from valid records only) to Kafka.
     doubled.to(outputTopic, Produced.with(stringSerde, longSerde));
 
-    final KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfiguration);
-    streams.start();
+    final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration);
 
-    //
-    // Step 2: Produce some corrupt input data to the input topic.
-    //
-    final Properties producerConfigForCorruptRecords = new Properties();
-    producerConfigForCorruptRecords.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    producerConfigForCorruptRecords.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfigForCorruptRecords.put(ProducerConfig.RETRIES_CONFIG, 0);
-    producerConfigForCorruptRecords.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
-    producerConfigForCorruptRecords.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-    IntegrationTestUtils.produceValuesSynchronously(inputTopic,
-        Collections.singletonList("corrupt"), producerConfigForCorruptRecords);
+    try {
+      //
+      // Step 2: Produce some corrupt input data to the input topic.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        inputTopic,
+        Collections.singletonList(new KeyValue<>(null, "corrupt")),
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new StringSerializer()
+      );
 
-    //
-    // Step 3: Produce some (valid) input data to the input topic.
-    //
-    final Properties producerConfig = new Properties();
-    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
-    producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
-    producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
-    IntegrationTestUtils.produceValuesSynchronously(inputTopic, inputValues, producerConfig);
+      //
+      // Step 3: Produce some (valid) input data to the input topic.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        inputTopic,
+        inputValues.stream().map(v -> new KeyValue<>(null, v)).collect(Collectors.toList()),
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new LongSerializer()
+      );
 
-    //
-    // Step 4: Verify the application's output data.
-    //
-    final Properties consumerConfig = new Properties();
-    consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "map-function-lambda-integration-test-standard-consumer");
-    consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-    consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-    consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
-    final List<Long> actualValues = IntegrationTestUtils.waitUntilMinValuesRecordsReceived(consumerConfig,
-        outputTopic, expectedValues.size());
-    streams.close();
-    assertThat(actualValues).isEqualTo(expectedValues);
+      //
+      // Step 4: Verify the application's output data.
+      //
+      final List<Long> actualValues = IntegrationTestUtils.drainStreamOutput(
+        outputTopic,
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new LongDeserializer()
+      ).stream().map(kv -> kv.value).collect(Collectors.toList());
+      assertThat(actualValues).isEqualTo(expectedValues);
+    } finally {
+      topologyTestDriver.close();
+    }
   }
 }

--- a/src/test/java/io/confluent/examples/streams/MapFunctionLambdaIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/MapFunctionLambdaIntegrationTest.java
@@ -15,20 +15,15 @@
  */
 package io.confluent.examples.streams;
 
-import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.KStream;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.apache.kafka.streams.kstream.ValueMapper;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -40,25 +35,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * End-to-end integration test based on MapFunctionLambdaExample, using an embedded Kafka cluster.
- *
+ * <p>
  * Note: This example uses lambda expressions and thus works with Java 8+ only.
  */
 public class MapFunctionLambdaIntegrationTest {
 
-  @ClassRule
-  public static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster();
-
-  private static String inputTopic = "inputTopic";
-  private static String outputTopic = "outputTopic";
-
-  @BeforeClass
-  public static void startKafkaCluster() {
-    CLUSTER.createTopic(inputTopic);
-    CLUSTER.createTopic(outputTopic);
-  }
-
   @Test
-  public void shouldUppercaseTheInput() throws Exception {
+  public void shouldUppercaseTheInput() {
     final List<String> inputValues = Arrays.asList("hello", "world");
     final List<String> expectedValues = inputValues.stream().map(String::toUpperCase).collect(Collectors.toList());
 
@@ -69,41 +52,42 @@ public class MapFunctionLambdaIntegrationTest {
 
     final Properties streamsConfiguration = new Properties();
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "map-function-lambda-integration-test");
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
     streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArray().getClass().getName());
     streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
-    streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
+    final String inputTopic = "inputTopic";
+    final String outputTopic = "outputTopic";
     final KStream<byte[], String> input = builder.stream(inputTopic);
-    final KStream<byte[], String> uppercased = input.mapValues(v -> v.toUpperCase());
+    final KStream<byte[], String> uppercased = input.mapValues((ValueMapper<String, String>) String::toUpperCase);
     uppercased.to(outputTopic);
 
-    final KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfiguration);
-    streams.start();
+    final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration);
 
-    //
-    // Step 2: Produce some input data to the input topic.
-    //
-    final Properties producerConfig = new Properties();
-    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
-    producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
-    producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-    IntegrationTestUtils.produceValuesSynchronously(inputTopic, inputValues, producerConfig);
+    try {
+      //
+      // Step 2: Produce some input data to the input topic.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        inputTopic,
+        inputValues.stream().map(v -> new KeyValue<>(null, v)).collect(Collectors.toList()),
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new StringSerializer()
+      );
 
-    //
-    // Step 3: Verify the application's output data.
-    //
-    final Properties consumerConfig = new Properties();
-    consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "map-function-lambda-integration-test-standard-consumer");
-    consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-    consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-    consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    final List<String> actualValues = IntegrationTestUtils.waitUntilMinValuesRecordsReceived(consumerConfig,
-        outputTopic, expectedValues.size());
-    streams.close();
-    assertThat(actualValues).isEqualTo(expectedValues);
+      //
+      // Step 3: Verify the application's output data.
+      //
+      final List<String> actualValues = IntegrationTestUtils.drainStreamOutput(
+        outputTopic,
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new StringDeserializer()
+      ).stream().map(kv -> kv.value).collect(Collectors.toList());
+      assertThat(actualValues).isEqualTo(expectedValues);
+    } finally {
+      topologyTestDriver.close();
+    }
   }
 }

--- a/src/test/java/io/confluent/examples/streams/MapFunctionLambdaIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/MapFunctionLambdaIntegrationTest.java
@@ -59,7 +59,7 @@ public class MapFunctionLambdaIntegrationTest {
     final String inputTopic = "inputTopic";
     final String outputTopic = "outputTopic";
     final KStream<byte[], String> input = builder.stream(inputTopic);
-    final KStream<byte[], String> uppercased = input.mapValues((ValueMapper<String, String>) String::toUpperCase);
+    final KStream<byte[], String> uppercased = input.mapValues(s -> s.toUpperCase());
     uppercased.to(outputTopic);
 
     final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration);

--- a/src/test/java/io/confluent/examples/streams/MixAndMatchLambdaIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/MixAndMatchLambdaIntegrationTest.java
@@ -15,64 +15,47 @@
  */
 package io.confluent.examples.streams;
 
-import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.kstream.TransformerSupplier;
+import org.apache.kafka.streams.kstream.ValueMapper;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * End-to-end integration test that demonstrates how to mix and match the DSL and the Processor
  * API of Kafka Streams.
- *
+ * <p>
  * More concretely, we show how to use the {@link KStream#transform(TransformerSupplier, String...)}
  * method to include a custom {@link org.apache.kafka.streams.kstream.Transformer} (from the
  * Processor API) in a topology defined via the DSL.  The fictitious use case is to anonymize
  * IPv4 addresses contained in the input data.
- *
+ * <p>
  * Tip: Users that want to use {@link KStream#process(ProcessorSupplier, String...)} would need to
  * include a custom {@link org.apache.kafka.streams.processor.Processor}.  Keep in mind though that
  * the return type of {@link KStream#process(ProcessorSupplier, String...)} is `void`, which means
  * you cannot add further operators (such as `to()` as we do below) after having called `process()`.
  * If you need to add further operators, you'd have to use `transform()` as we do in this example.
- *
+ * <p>
  * Note: This example uses lambda expressions and thus works with Java 8+ only.
  */
 public class MixAndMatchLambdaIntegrationTest {
-
-  @ClassRule
-  public static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster();
-
-  private static String inputTopic = "inputTopic";
-  private static String outputTopic = "outputTopic";
-
-  @BeforeClass
-  public static void startKafkaCluster() {
-    CLUSTER.createTopic(inputTopic);
-    CLUSTER.createTopic(outputTopic);
-  }
 
   /**
    * Performs rudimentary anonymization of IPv4 address in the input data.
@@ -80,11 +63,10 @@ public class MixAndMatchLambdaIntegrationTest {
    */
   private static class AnonymizeIpAddressTransformer implements Transformer<byte[], String, KeyValue<byte[], String>> {
 
-    private static Pattern ipv4AddressPattern =
-        Pattern.compile("(?<keep>[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.)(?<anonymize>[0-9]{1,3})");
+    private static final Pattern ipv4AddressPattern =
+      Pattern.compile("(?<keep>[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.)(?<anonymize>[0-9]{1,3})");
 
     @Override
-    @SuppressWarnings("unchecked")
     public void init(final ProcessorContext context) {
       // Not needed.
     }
@@ -100,7 +82,7 @@ public class MixAndMatchLambdaIntegrationTest {
     /**
      * Anonymizes the provided IPv4 address (in string representation) by replacing the fourth byte
      * with "XXX".  For example, "192.168.1.234" is anonymized to "192.168.1.XXX".
-     *
+     * <p>
      * Note: This method is for illustration purposes only.  The anonymization is both lackluster
      * (in terms of the achieved anonymization) and slow/inefficient (in terms of implementation).
      *
@@ -126,7 +108,7 @@ public class MixAndMatchLambdaIntegrationTest {
 
 
   @Test
-  public void shouldAnonymizeTheInput() throws Exception {
+  public void shouldAnonymizeTheInput() {
     final List<String> inputValues = Arrays.asList("Hello, 1.2.3.4!", "foo 192.168.1.55 bar");
     final List<String> expectedValues = Arrays.asList("HELLO, 1.2.3.XXX!", "FOO 192.168.1.XXX BAR");
 
@@ -137,44 +119,47 @@ public class MixAndMatchLambdaIntegrationTest {
 
     final Properties streamsConfiguration = new Properties();
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "mix-and-match-lambda-integration-test");
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
     streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArray().getClass().getName());
     streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
-    streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+    final String inputTopic = "inputTopic";
+    final String outputTopic = "outputTopic";
 
     final KStream<byte[], String> input = builder.stream(inputTopic);
     final KStream<byte[], String> uppercasedAndAnonymized = input
-        .mapValues(v -> v.toUpperCase())
-        .transform(AnonymizeIpAddressTransformer::new);
+      .mapValues((ValueMapper<String, String>) String::toUpperCase)
+      .transform(AnonymizeIpAddressTransformer::new);
     uppercasedAndAnonymized.to(outputTopic);
 
-    final KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfiguration);
-    streams.start();
+    final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration);
 
-    //
-    // Step 2: Produce some input data to the input topic.
-    //
-    final Properties producerConfig = new Properties();
-    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
-    producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
-    producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-    IntegrationTestUtils.produceValuesSynchronously(inputTopic, inputValues, producerConfig);
+    try {
+      //
+      // Step 2: Produce some input data to the input topic.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        inputTopic,
+        inputValues.stream().map(v -> new KeyValue<>(null, v)).collect(Collectors.toList()),
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new StringSerializer()
+      );
 
-    //
-    // Step 3: Verify the application's output data.
-    //
-    final Properties consumerConfig = new Properties();
-    consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "mix-and-match-lambda-integration-test-standard-consumer");
-    consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-    consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-    consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    final List<String> actualValues = IntegrationTestUtils.waitUntilMinValuesRecordsReceived(consumerConfig,
-        outputTopic, expectedValues.size());
-    streams.close();
-    assertThat(actualValues).isEqualTo(expectedValues);
+      //
+      // Step 3: Verify the application's output data.
+      //
+      final List<String> actualValues = IntegrationTestUtils.drainStreamOutput(
+        outputTopic,
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new StringDeserializer()
+      ).stream().map(kv -> kv.value).collect(Collectors.toList());
+      assertThat(actualValues).isEqualTo(expectedValues);
+    } finally {
+      topologyTestDriver.close();
+    }
   }
+
 
 }

--- a/src/test/java/io/confluent/examples/streams/MixAndMatchLambdaIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/MixAndMatchLambdaIntegrationTest.java
@@ -128,7 +128,7 @@ public class MixAndMatchLambdaIntegrationTest {
 
     final KStream<byte[], String> input = builder.stream(inputTopic);
     final KStream<byte[], String> uppercasedAndAnonymized = input
-      .mapValues((ValueMapper<String, String>) String::toUpperCase)
+      .mapValues(s -> s.toUpperCase())
       .transform(AnonymizeIpAddressTransformer::new);
     uppercasedAndAnonymized.to(outputTopic);
 

--- a/src/test/java/io/confluent/examples/streams/PassThroughIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/PassThroughIntegrationTest.java
@@ -59,39 +59,42 @@ public class PassThroughIntegrationTest {
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
     streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
     streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
-    streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
     // Write the input data as-is to the output topic.
     builder.stream(inputTopic).to(outputTopic);
 
     final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration);
 
-    //
-    // Step 2: Produce some input data to the input topic.
-    //
-    IntegrationTestUtils.produceKeyValuesSynchronously(
-      inputTopic,
-      inputValues.stream().map(v -> new KeyValue<>(null, v)).collect(Collectors.toList()),
-      topologyTestDriver,
-      new IntegrationTestUtils.NothingSerde<>(),
-      new StringSerializer()
-    );
-
-    //
-    // Step 3: Verify the application's output data.
-    //
-    final List<String> actualValues =
-      IntegrationTestUtils.drainStreamOutput(
-        outputTopic,
+    try {
+      //
+      // Step 2: Produce some input data to the input topic.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        inputTopic,
+        inputValues.stream().map(v -> new KeyValue<>(null, v)).collect(Collectors.toList()),
         topologyTestDriver,
         new IntegrationTestUtils.NothingSerde<>(),
-        new StringDeserializer()
-      )
-        .stream()
-        .map(kv -> kv.value)
-        .collect(Collectors.toList());
+        new StringSerializer()
+      );
 
-    assertThat(actualValues).isEqualTo(inputValues);
+      //
+      // Step 3: Verify the application's output data.
+      //
+      final List<String> actualValues =
+        IntegrationTestUtils.drainStreamOutput(
+          outputTopic,
+          topologyTestDriver,
+          new IntegrationTestUtils.NothingSerde<>(),
+          new StringDeserializer()
+        )
+          .stream()
+          .map(kv -> kv.value)
+          .collect(Collectors.toList());
+
+      assertThat(actualValues).isEqualTo(inputValues);
+    } finally {
+      topologyTestDriver.close();
+    }
   }
 
 }

--- a/src/test/java/io/confluent/examples/streams/StateStoresInTheDSLIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/StateStoresInTheDSLIntegrationTest.java
@@ -139,7 +139,6 @@ public class StateStoresInTheDSLIntegrationTest {
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
     streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArray().getClass().getName());
     streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
-    streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     // Use a temporary directory for storing state, which will be automatically removed after the test.
     streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
 
@@ -171,27 +170,31 @@ public class StateStoresInTheDSLIntegrationTest {
 
     final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration);
 
-    //
-    // Step 2: Produce some input data to the input topic.
-    //
-    IntegrationTestUtils.produceKeyValuesSynchronously(
-      inputTopic,
-      inputValues.stream().map(v -> new KeyValue<>(null, v)).collect(Collectors.toList()),
-      topologyTestDriver,
-      new IntegrationTestUtils.NothingSerde<>(),
-      new StringSerializer()
-    );
+    try {
+      //
+      // Step 2: Produce some input data to the input topic.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        inputTopic,
+        inputValues.stream().map(v -> new KeyValue<>(null, v)).collect(Collectors.toList()),
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new StringSerializer()
+      );
 
-    //
-    // Step 3: Verify the application's output data.
-    //
-    final List<KeyValue<String, Long>> actualValues = IntegrationTestUtils.drainStreamOutput(
-      outputTopic,
-      topologyTestDriver,
-      new StringDeserializer(),
-      new LongDeserializer()
-    );
-    assertThat(actualValues).isEqualTo(expectedRecords);
+      //
+      // Step 3: Verify the application's output data.
+      //
+      final List<KeyValue<String, Long>> actualValues = IntegrationTestUtils.drainStreamOutput(
+        outputTopic,
+        topologyTestDriver,
+        new StringDeserializer(),
+        new LongDeserializer()
+      );
+      assertThat(actualValues).isEqualTo(expectedRecords);
+    } finally {
+      topologyTestDriver.close();
+    }
   }
 
 }

--- a/src/test/java/io/confluent/examples/streams/StreamToStreamJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/StreamToStreamJoinIntegrationTest.java
@@ -54,44 +54,39 @@ public class StreamToStreamJoinIntegrationTest {
   private static final String outputTopic = "output-topic";
 
   @Test
-  public void shouldJoinTwoStreams() throws Exception {
+  public void shouldJoinTwoStreams() {
     // Input 1: Ad impressions
     final List<KeyValue<String, String>> inputAdImpressions = Arrays.asList(
-        new KeyValue<>("car-advertisement", "shown"),
-        new KeyValue<>("newspaper-advertisement", "shown"),
-        new KeyValue<>("gadget-advertisement", "shown")
+      new KeyValue<>("car-advertisement", "shown"),
+      new KeyValue<>("newspaper-advertisement", "shown"),
+      new KeyValue<>("gadget-advertisement", "shown")
     );
 
     // Input 2: Ad clicks
     final List<KeyValue<String, String>> inputAdClicks = Arrays.asList(
-        new KeyValue<>("newspaper-advertisement", "clicked"),
-        new KeyValue<>("gadget-advertisement", "clicked"),
-        new KeyValue<>("newspaper-advertisement", "clicked")
+      new KeyValue<>("newspaper-advertisement", "clicked"),
+      new KeyValue<>("gadget-advertisement", "clicked"),
+      new KeyValue<>("newspaper-advertisement", "clicked")
     );
 
     final List<KeyValue<String, String>> expectedResults = Arrays.asList(
-        new KeyValue<>("car-advertisement", "shown/null"),
-        new KeyValue<>("newspaper-advertisement", "shown/null"),
-        new KeyValue<>("gadget-advertisement", "shown/null"),
-        new KeyValue<>("newspaper-advertisement", "shown/clicked"),
-        new KeyValue<>("gadget-advertisement", "shown/clicked"),
-        new KeyValue<>("newspaper-advertisement", "shown/clicked")
+      new KeyValue<>("car-advertisement", "shown/null"),
+      new KeyValue<>("newspaper-advertisement", "shown/null"),
+      new KeyValue<>("gadget-advertisement", "shown/null"),
+      new KeyValue<>("newspaper-advertisement", "shown/clicked"),
+      new KeyValue<>("gadget-advertisement", "shown/clicked"),
+      new KeyValue<>("newspaper-advertisement", "shown/clicked")
     );
 
     //
     // Step 1: Configure and start the processor topology.
     //
-    final Serde<String> stringSerde = Serdes.String();
 
     final Properties streamsConfiguration = new Properties();
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "stream-stream-join-lambda-integration-test");
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
     streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
     streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
-    // The commit interval for flushing records to state stores and downstream must be lower than
-    // this integration test's timeout (30 secs) to ensure we observe the expected processing results.
-    streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 10 * 1000);
-    streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     // Use a temporary directory for storing state, which will be automatically removed after the test.
     streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
 
@@ -104,48 +99,52 @@ public class StreamToStreamJoinIntegrationTest {
     // for the same join key (e.g. "newspaper-advertisement"), we receive an update from either of
     // the two joined streams during the defined join window.
     final KStream<String, String> impressionsAndClicks = alerts.outerJoin(incidents,
-        (impressionValue, clickValue) -> impressionValue + "/" + clickValue,
-        // KStream-KStream joins are always windowed joins, hence we must provide a join window.
-        JoinWindows.of(TimeUnit.SECONDS.toMillis(5)));
+      (impressionValue, clickValue) -> impressionValue + "/" + clickValue,
+      // KStream-KStream joins are always windowed joins, hence we must provide a join window.
+      JoinWindows.of(TimeUnit.SECONDS.toMillis(5)));
 
     // Write the results to the output topic.
     impressionsAndClicks.to(outputTopic);
 
     final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration);
 
-    //
-    // Step 2: Publish ad impressions.
-    //
-    IntegrationTestUtils.produceKeyValuesSynchronously(
-      adImpressionsTopic,
-      inputAdImpressions,
-      topologyTestDriver,
-      new StringSerializer(),
-      new StringSerializer()
-    );
-
-    //
-    // Step 3: Publish ad clicks.
-    //
-    IntegrationTestUtils.produceKeyValuesSynchronously(
-      adClicksTopic,
-      inputAdClicks,
-      topologyTestDriver,
-      new StringSerializer(),
-      new StringSerializer()
-    );
-
-    //
-    // Step 4: Verify the application's output data.
-    //
-    final List<KeyValue<String, String>> actualResults =
-      IntegrationTestUtils.drainStreamOutput(
-        outputTopic,
+    try {
+      //
+      // Step 2: Publish ad impressions.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        adImpressionsTopic,
+        inputAdImpressions,
         topologyTestDriver,
-        new StringDeserializer(),
-        new StringDeserializer()
+        new StringSerializer(),
+        new StringSerializer()
       );
-    assertThat(actualResults).containsExactlyElementsOf(expectedResults);
+
+      //
+      // Step 3: Publish ad clicks.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        adClicksTopic,
+        inputAdClicks,
+        topologyTestDriver,
+        new StringSerializer(),
+        new StringSerializer()
+      );
+
+      //
+      // Step 4: Verify the application's output data.
+      //
+      final List<KeyValue<String, String>> actualResults =
+        IntegrationTestUtils.drainStreamOutput(
+          outputTopic,
+          topologyTestDriver,
+          new StringDeserializer(),
+          new StringDeserializer()
+        );
+      assertThat(actualResults).containsExactlyElementsOf(expectedResults);
+    } finally {
+      topologyTestDriver.close();
+    }
   }
 
 }

--- a/src/test/java/io/confluent/examples/streams/StreamToTableJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/StreamToTableJoinIntegrationTest.java
@@ -15,7 +15,6 @@
  */
 package io.confluent.examples.streams;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serde;
@@ -65,7 +64,7 @@ public class StreamToTableJoinIntegrationTest {
     private final String region;
     private final long clicks;
 
-    public RegionWithClicks(final String region, final long clicks) {
+    RegionWithClicks(final String region, final long clicks) {
       if (region == null || region.isEmpty()) {
         throw new IllegalArgumentException("region must be set");
       }
@@ -76,39 +75,39 @@ public class StreamToTableJoinIntegrationTest {
       this.clicks = clicks;
     }
 
-    public String getRegion() {
+    String getRegion() {
       return region;
     }
 
-    public long getClicks() {
+    long getClicks() {
       return clicks;
     }
 
   }
 
   @Test
-  public void shouldCountClicksPerRegion() throws Exception {
+  public void shouldCountClicksPerRegion() {
     // Input 1: Clicks per user (multiple records allowed per user).
     final List<KeyValue<String, Long>> userClicks = Arrays.asList(
-        new KeyValue<>("alice", 13L),
-        new KeyValue<>("bob", 4L),
-        new KeyValue<>("chao", 25L),
-        new KeyValue<>("bob", 19L),
-        new KeyValue<>("dave", 56L),
-        new KeyValue<>("eve", 78L),
-        new KeyValue<>("alice", 40L),
-        new KeyValue<>("fang", 99L)
+      new KeyValue<>("alice", 13L),
+      new KeyValue<>("bob", 4L),
+      new KeyValue<>("chao", 25L),
+      new KeyValue<>("bob", 19L),
+      new KeyValue<>("dave", 56L),
+      new KeyValue<>("eve", 78L),
+      new KeyValue<>("alice", 40L),
+      new KeyValue<>("fang", 99L)
     );
 
     // Input 2: Region per user (multiple records allowed per user).
     final List<KeyValue<String, String>> userRegions = Arrays.asList(
-        new KeyValue<>("alice", "asia"),   /* Alice lived in Asia originally... */
-        new KeyValue<>("bob", "americas"),
-        new KeyValue<>("chao", "asia"),
-        new KeyValue<>("dave", "europe"),
-        new KeyValue<>("alice", "europe"), /* ...but moved to Europe some time later. */
-        new KeyValue<>("eve", "americas"),
-        new KeyValue<>("fang", "asia")
+      new KeyValue<>("alice", "asia"),   /* Alice lived in Asia originally... */
+      new KeyValue<>("bob", "americas"),
+      new KeyValue<>("chao", "asia"),
+      new KeyValue<>("dave", "europe"),
+      new KeyValue<>("alice", "europe"), /* ...but moved to Europe some time later. */
+      new KeyValue<>("eve", "americas"),
+      new KeyValue<>("fang", "asia")
     );
 
     final Map<String, Long> expectedClicksPerRegion = mkMap(
@@ -128,10 +127,6 @@ public class StreamToTableJoinIntegrationTest {
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
     streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
     streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
-    // The commit interval for flushing records to state stores and downstream must be lower than
-    // this integration test's timeout (30 secs) to ensure we observe the expected processing results.
-    streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 10 * 1000);
-    streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     // Use a temporary directory for storing state, which will be automatically removed after the test.
     streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
 
@@ -161,64 +156,68 @@ public class StreamToTableJoinIntegrationTest {
     // The resulting KTable is continuously being updated as new data records are arriving in the
     // input KStream `userClicksStream` and input KTable `userRegionsTable`.
     final KTable<String, Long> clicksPerRegion = userClicksStream
-        // Join the stream against the table.
-        //
-        // Null values possible: In general, null values are possible for region (i.e. the value of
-        // the KTable we are joining against) so we must guard against that (here: by setting the
-        // fallback region "UNKNOWN").  In this specific example this is not really needed because
-        // we know, based on the test setup, that all users have appropriate region entries at the
-        // time we perform the join.
-        //
-        // Also, we need to return a tuple of (region, clicks) for each user.  But because Java does
-        // not support tuples out-of-the-box, we must use a custom class `RegionWithClicks` to
-        // achieve the same effect.
-        .leftJoin(userRegionsTable, (clicks, region) -> new RegionWithClicks(region == null ? "UNKNOWN" : region, clicks))
-        // Change the stream from <user> -> <region, clicks> to <region> -> <clicks>
-        .map((user, regionWithClicks) -> new KeyValue<>(regionWithClicks.getRegion(), regionWithClicks.getClicks()))
-        // Compute the total per region by summing the individual click counts per region.
-        .groupByKey(Serialized.with(stringSerde, longSerde))
-        .reduce((firstClicks, secondClicks) -> firstClicks + secondClicks);
+      // Join the stream against the table.
+      //
+      // Null values possible: In general, null values are possible for region (i.e. the value of
+      // the KTable we are joining against) so we must guard against that (here: by setting the
+      // fallback region "UNKNOWN").  In this specific example this is not really needed because
+      // we know, based on the test setup, that all users have appropriate region entries at the
+      // time we perform the join.
+      //
+      // Also, we need to return a tuple of (region, clicks) for each user.  But because Java does
+      // not support tuples out-of-the-box, we must use a custom class `RegionWithClicks` to
+      // achieve the same effect.
+      .leftJoin(userRegionsTable, (clicks, region) -> new RegionWithClicks(region == null ? "UNKNOWN" : region, clicks))
+      // Change the stream from <user> -> <region, clicks> to <region> -> <clicks>
+      .map((user, regionWithClicks) -> new KeyValue<>(regionWithClicks.getRegion(), regionWithClicks.getClicks()))
+      // Compute the total per region by summing the individual click counts per region.
+      .groupByKey(Serialized.with(stringSerde, longSerde))
+      .reduce((firstClicks, secondClicks) -> firstClicks + secondClicks);
 
     // Write the (continuously updating) results to the output topic.
     clicksPerRegion.toStream().to(outputTopic, Produced.with(stringSerde, longSerde));
 
     final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration);
 
-    //
-    // Step 2: Publish user-region information.
-    //
-    // To keep this code example simple and easier to understand/reason about, we publish all
-    // user-region records before any user-click records (cf. step 3).  In practice though,
-    // data records would typically be arriving concurrently in both input streams/topics.
-    IntegrationTestUtils.produceKeyValuesSynchronously(
-      userRegionsTopic,
-      userRegions,
-      topologyTestDriver,
-      new StringSerializer(),
-      new StringSerializer()
-    );
-
-    //
-    // Step 3: Publish some user click events.
-    //
-    IntegrationTestUtils.produceKeyValuesSynchronously(
-      userClicksTopic,
-      userClicks,
-      topologyTestDriver,
-      new StringSerializer(),
-      new LongSerializer());
-
-    //
-    // Step 4: Verify the application's output data.
-    //
-    final Map<String, Long> actualClicksPerRegion =
-      IntegrationTestUtils.drainTableOutput(
-        outputTopic,
+    try {
+      //
+      // Step 2: Publish user-region information.
+      //
+      // To keep this code example simple and easier to understand/reason about, we publish all
+      // user-region records before any user-click records (cf. step 3).  In practice though,
+      // data records would typically be arriving concurrently in both input streams/topics.
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        userRegionsTopic,
+        userRegions,
         topologyTestDriver,
-        new StringDeserializer(),
-        new LongDeserializer()
+        new StringSerializer(),
+        new StringSerializer()
       );
-    assertThat(actualClicksPerRegion).isEqualTo(expectedClicksPerRegion);
+
+      //
+      // Step 3: Publish some user click events.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        userClicksTopic,
+        userClicks,
+        topologyTestDriver,
+        new StringSerializer(),
+        new LongSerializer());
+
+      //
+      // Step 4: Verify the application's output data.
+      //
+      final Map<String, Long> actualClicksPerRegion =
+        IntegrationTestUtils.drainTableOutput(
+          outputTopic,
+          topologyTestDriver,
+          new StringDeserializer(),
+          new LongDeserializer()
+        );
+      assertThat(actualClicksPerRegion).isEqualTo(expectedClicksPerRegion);
+    } finally {
+      topologyTestDriver.close();
+    }
   }
 
 }

--- a/src/test/java/io/confluent/examples/streams/SumLambdaIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/SumLambdaIntegrationTest.java
@@ -15,7 +15,6 @@
  */
 package io.confluent.examples.streams;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
@@ -40,11 +39,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class SumLambdaIntegrationTest {
 
-  private static String inputTopic = SumLambdaExample.NUMBERS_TOPIC;
-  private static String outputTopic = SumLambdaExample.SUM_OF_ODD_NUMBERS_TOPIC;
-
   @Test
-  public void shouldSumEvenNumbers() throws Exception {
+  public void shouldSumEvenNumbers() {
     final List<Integer> inputValues = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     final List<KeyValue<Integer, Integer>> expectedValues = Arrays.asList(
       new KeyValue<>(1, 1),
@@ -62,37 +58,37 @@ public class SumLambdaIntegrationTest {
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
     streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass().getName());
     streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass().getName());
-    // The commit interval for flushing records to state stores and downstream must be lower than
-    // this integration test's timeout (30 secs) to ensure we observe the expected processing results.
-    streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 10 * 1000);
-    streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     // Use a temporary directory for storing state, which will be automatically removed after the test.
     streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
 
     final TopologyTestDriver topologyTestDriver =
       new TopologyTestDriver(SumLambdaExample.getTopology(), streamsConfiguration);
 
-    //
-    // Step 2: Produce some input data to the input topic.
-    //
-    IntegrationTestUtils.produceKeyValuesSynchronously(
-      inputTopic,
-      inputValues.stream().map(i -> new KeyValue<Void, Integer>(null, i)).collect(Collectors.toList()),
-      topologyTestDriver,
-      new IntegrationTestUtils.NothingSerde<>(),
-      new IntegerSerializer()
-    );
+    try {
+      //
+      // Step 2: Produce some input data to the input topic.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        SumLambdaExample.NUMBERS_TOPIC,
+        inputValues.stream().map(i -> new KeyValue<Void, Integer>(null, i)).collect(Collectors.toList()),
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new IntegerSerializer()
+      );
 
-    //
-    // Step 3: Verify the application's output data.
-    //
-    final List<KeyValue<Integer, Integer>> actualValues = IntegrationTestUtils.drainStreamOutput(
-      outputTopic,
-      topologyTestDriver,
-      new IntegerDeserializer(),
-      new IntegerDeserializer()
-    );
-    assertThat(actualValues).isEqualTo(expectedValues);
+      //
+      // Step 3: Verify the application's output data.
+      //
+      final List<KeyValue<Integer, Integer>> actualValues = IntegrationTestUtils.drainStreamOutput(
+        SumLambdaExample.SUM_OF_ODD_NUMBERS_TOPIC,
+        topologyTestDriver,
+        new IntegerDeserializer(),
+        new IntegerDeserializer()
+      );
+      assertThat(actualValues).isEqualTo(expectedValues);
+    } finally {
+      topologyTestDriver.close();
+    }
   }
 
 }

--- a/src/test/java/io/confluent/examples/streams/TableToTableJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/TableToTableJoinIntegrationTest.java
@@ -15,7 +15,6 @@
  */
 package io.confluent.examples.streams;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
@@ -57,31 +56,31 @@ public class TableToTableJoinIntegrationTest {
   public void shouldJoinTwoTables() {
     // Input: Region per user (multiple records allowed per user).
     final List<KeyValue<String, String>> userRegionRecords = Arrays.asList(
-        new KeyValue<>("alice", "asia"),
-        new KeyValue<>("bob", "europe"),
-        new KeyValue<>("alice", "europe"),
-        new KeyValue<>("charlie", "europe"),
-        new KeyValue<>("bob", "asia")
+      new KeyValue<>("alice", "asia"),
+      new KeyValue<>("bob", "europe"),
+      new KeyValue<>("alice", "europe"),
+      new KeyValue<>("charlie", "europe"),
+      new KeyValue<>("bob", "asia")
     );
 
     // Input 2: Timestamp of last login per user (multiple records allowed per user)
     final List<KeyValue<String, Long>> userLastLoginRecords = Arrays.asList(
-        new KeyValue<>("alice", 1485500000L),
-        new KeyValue<>("bob", 1485520000L),
-        new KeyValue<>("alice", 1485530000L),
-        new KeyValue<>("bob", 1485560000L)
+      new KeyValue<>("alice", 1485500000L),
+      new KeyValue<>("bob", 1485520000L),
+      new KeyValue<>("alice", 1485530000L),
+      new KeyValue<>("bob", 1485560000L)
     );
 
     final List<KeyValue<String, String>> expectedResults = Arrays.asList(
-        new KeyValue<>("alice", "europe/1485500000"),
-        new KeyValue<>("bob", "asia/1485520000"),
-        new KeyValue<>("alice", "europe/1485530000"),
-        new KeyValue<>("bob", "asia/1485560000")
+      new KeyValue<>("alice", "europe/1485500000"),
+      new KeyValue<>("bob", "asia/1485520000"),
+      new KeyValue<>("alice", "europe/1485530000"),
+      new KeyValue<>("bob", "asia/1485560000")
     );
 
     final List<KeyValue<String, String>> expectedResultsForJoinStateStore = Arrays.asList(
-        new KeyValue<>("alice", "europe/1485530000"),
-        new KeyValue<>("bob", "asia/1485560000")
+      new KeyValue<>("alice", "europe/1485530000"),
+      new KeyValue<>("bob", "asia/1485560000")
     );
 
     //
@@ -95,12 +94,6 @@ public class TableToTableJoinIntegrationTest {
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
     streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
     streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
-    // For didactic reasons: disable record caching so we can observe every individual update record being sent downstream
-    streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
-    // The commit interval for flushing records to state stores and downstream must be lower than
-    // this integration test's timeout (30 secs) to ensure we observe the expected processing results.
-    streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 10 * 1000);
-    streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     // Use a temporary directory for storing state, which will be automatically removed after the test.
     streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
 
@@ -110,53 +103,57 @@ public class TableToTableJoinIntegrationTest {
 
     final String storeName = "joined-store";
     userRegions.join(userLastLogins,
-        (regionValue, lastLoginValue) -> regionValue + "/" + lastLoginValue,
-        Materialized.as(storeName))
-        .toStream()
-        .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+      (regionValue, lastLoginValue) -> regionValue + "/" + lastLoginValue,
+      Materialized.as(storeName))
+      .toStream()
+      .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
 
     final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration);
 
-    //
-    // Step 2: Publish user regions.
-    //
-    IntegrationTestUtils.produceKeyValuesSynchronously(
-      userRegionTopic,
-      userRegionRecords,
-      topologyTestDriver,
-      new StringSerializer(),
-      new StringSerializer()
-    );
+    try {
+      //
+      // Step 2: Publish user regions.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        userRegionTopic,
+        userRegionRecords,
+        topologyTestDriver,
+        new StringSerializer(),
+        new StringSerializer()
+      );
 
-    //
-    // Step 3: Publish user's last login timestamps.
-    //
-    IntegrationTestUtils.produceKeyValuesSynchronously(
-      userLastLoginTopic,
-      userLastLoginRecords,
-      topologyTestDriver,
-      new StringSerializer(),
-      new LongSerializer()
-    );
+      //
+      // Step 3: Publish user's last login timestamps.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        userLastLoginTopic,
+        userLastLoginRecords,
+        topologyTestDriver,
+        new StringSerializer(),
+        new LongSerializer()
+      );
 
-    //
-    // Step 4: Verify the application's output data.
-    //
-    final List<KeyValue<String, String>> actualResults = IntegrationTestUtils.drainStreamOutput(
-      outputTopic,
-      topologyTestDriver,
-      new StringDeserializer(),
-      new StringDeserializer()
-    );
+      //
+      // Step 4: Verify the application's output data.
+      //
+      final List<KeyValue<String, String>> actualResults = IntegrationTestUtils.drainStreamOutput(
+        outputTopic,
+        topologyTestDriver,
+        new StringDeserializer(),
+        new StringDeserializer()
+      );
 
-    // Verify the (local) state store of the joined table.
-    // For a comprehensive demonstration of interactive queries please refer to KafkaMusicExample.
-    final ReadOnlyKeyValueStore<String, String> readOnlyKeyValueStore =
+      // Verify the (local) state store of the joined table.
+      // For a comprehensive demonstration of interactive queries please refer to KafkaMusicExample.
+      final ReadOnlyKeyValueStore<String, String> readOnlyKeyValueStore =
         topologyTestDriver.getKeyValueStore(storeName);
-    final KeyValueIterator<String, String> keyValueIterator = readOnlyKeyValueStore.all();
-    assertThat(keyValueIterator).containsExactlyElementsOf(expectedResultsForJoinStateStore);
+      final KeyValueIterator<String, String> keyValueIterator = readOnlyKeyValueStore.all();
+      assertThat(keyValueIterator).containsExactlyElementsOf(expectedResultsForJoinStateStore);
 
-    assertThat(actualResults).containsExactlyElementsOf(expectedResults);
+      assertThat(actualResults).containsExactlyElementsOf(expectedResults);
+    } finally {
+      topologyTestDriver.close();
+    }
   }
 
 }

--- a/src/test/java/io/confluent/examples/streams/TableToTableJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/TableToTableJoinIntegrationTest.java
@@ -155,5 +155,4 @@ public class TableToTableJoinIntegrationTest {
       topologyTestDriver.close();
     }
   }
-
 }

--- a/src/test/java/io/confluent/examples/streams/UserCountsPerRegionLambdaIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/UserCountsPerRegionLambdaIntegrationTest.java
@@ -115,7 +115,6 @@ public class UserCountsPerRegionLambdaIntegrationTest {
       //
       // Step 2: Publish user-region information.
       //
-
       IntegrationTestUtils.produceKeyValuesSynchronously(
         inputTopic,
         userRegionRecords,

--- a/src/test/java/io/confluent/examples/streams/WordCountLambdaIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/WordCountLambdaIntegrationTest.java
@@ -15,79 +15,69 @@
  */
 package io.confluent.examples.streams;
 
-import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.test.TestUtils;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import static io.confluent.examples.streams.IntegrationTestUtils.mkEntry;
+import static io.confluent.examples.streams.IntegrationTestUtils.mkMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * End-to-end integration test based on {@link WordCountLambdaExample}, using an embedded Kafka
  * cluster.
- *
+ * <p>
  * See {@link WordCountLambdaExample} for further documentation.
- *
+ * <p>
  * See {@link WordCountScalaIntegrationTest} for the equivalent Scala example.
- *
+ * <p>
  * Note: This example uses lambda expressions and thus works with Java 8+ only.
  */
 public class WordCountLambdaIntegrationTest {
 
-  @ClassRule
-  public static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster();
-
   private static final String inputTopic = "inputTopic";
   private static final String outputTopic = "outputTopic";
 
-  @BeforeClass
-  public static void startKafkaCluster() throws Exception {
-    CLUSTER.createTopic(inputTopic);
-    CLUSTER.createTopic(outputTopic);
-  }
-
   @Test
-  public void shouldCountWords() throws Exception {
+  public void shouldCountWords() {
     final List<String> inputValues = Arrays.asList(
-        "Hello Kafka Streams",
-        "All streams lead to Kafka",
-        "Join Kafka Summit",
-        "И теперь пошли русские слова"
+      "Hello Kafka Streams",
+      "All streams lead to Kafka",
+      "Join Kafka Summit",
+      "И теперь пошли русские слова"
     );
-    final List<KeyValue<String, Long>> expectedWordCounts = Arrays.asList(
-        new KeyValue<>("hello", 1L),
-        new KeyValue<>("all", 1L),
-        new KeyValue<>("streams", 2L),
-        new KeyValue<>("lead", 1L),
-        new KeyValue<>("to", 1L),
-        new KeyValue<>("join", 1L),
-        new KeyValue<>("kafka", 3L),
-        new KeyValue<>("summit", 1L),
-        new KeyValue<>("и", 1L),
-        new KeyValue<>("теперь", 1L),
-        new KeyValue<>("пошли", 1L),
-        new KeyValue<>("русские", 1L),
-        new KeyValue<>("слова", 1L)
+    final Map<String, Long> expectedWordCounts = mkMap(
+      mkEntry("hello", 1L),
+      mkEntry("all", 1L),
+      mkEntry("streams", 2L),
+      mkEntry("lead", 1L),
+      mkEntry("to", 1L),
+      mkEntry("join", 1L),
+      mkEntry("kafka", 3L),
+      mkEntry("summit", 1L),
+      mkEntry("и", 1L),
+      mkEntry("теперь", 1L),
+      mkEntry("пошли", 1L),
+      mkEntry("русские", 1L),
+      mkEntry("слова", 1L)
     );
 
     //
@@ -98,13 +88,9 @@ public class WordCountLambdaIntegrationTest {
 
     final Properties streamsConfiguration = new Properties();
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "wordcount-lambda-integration-test");
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
     streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
     streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
-    // The commit interval for flushing records to state stores and downstream must be lower than
-    // this integration test's timeout (30 secs) to ensure we observe the expected processing results.
-    streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 10 * 1000);
-    streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     // Use a temporary directory for storing state, which will be automatically removed after the test.
     streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
 
@@ -115,40 +101,40 @@ public class WordCountLambdaIntegrationTest {
     final Pattern pattern = Pattern.compile("\\W+", Pattern.UNICODE_CHARACTER_CLASS);
 
     final KTable<String, Long> wordCounts = textLines
-        .flatMapValues(value -> Arrays.asList(pattern.split(value.toLowerCase())))
-        // no need to specify explicit serdes because the resulting key and value types match our default serde settings
-        .groupBy((key, word) -> word)
-        .count();
+      .flatMapValues(value -> Arrays.asList(pattern.split(value.toLowerCase())))
+      // no need to specify explicit serdes because the resulting key and value types match our default serde settings
+      .groupBy((key, word) -> word)
+      .count();
 
     wordCounts.toStream().to(outputTopic, Produced.with(stringSerde, longSerde));
 
-    final KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfiguration);
-    streams.start();
+    final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration);
 
-    //
-    // Step 2: Produce some input data to the input topic.
-    //
-    final Properties producerConfig = new Properties();
-    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
-    producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-    producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-    IntegrationTestUtils.produceValuesSynchronously(inputTopic, inputValues, producerConfig);
+    try {
+      //
+      // Step 2: Produce some input data to the input topic.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        inputTopic,
+        inputValues.stream().map(v -> new KeyValue<>(null, v)).collect(Collectors.toList()),
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new StringSerializer()
+      );
 
-    //
-    // Step 3: Verify the application's output data.
-    //
-    final Properties consumerConfig = new Properties();
-    consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "wordcount-lambda-integration-test-standard-consumer");
-    consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-    consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
-    final List<KeyValue<String, Long>> actualWordCounts = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerConfig,
-        outputTopic, expectedWordCounts.size());
-    streams.close();
-    assertThat(actualWordCounts).containsExactlyElementsOf(expectedWordCounts);
+      //
+      // Step 3: Verify the application's output data.
+      //
+      final Map<String, Long> actualWordCounts = IntegrationTestUtils.drainTableOutput(
+        outputTopic,
+        topologyTestDriver,
+        new StringDeserializer(),
+        new LongDeserializer()
+      );
+      assertThat(actualWordCounts).isEqualTo(expectedWordCounts);
+    } finally {
+      topologyTestDriver.close();
+    }
   }
 
 }

--- a/src/test/scala/io/confluent/examples/streams/ProbabilisticCountingScalaIntegrationTest.scala
+++ b/src/test/scala/io/confluent/examples/streams/ProbabilisticCountingScalaIntegrationTest.scala
@@ -18,17 +18,17 @@ package io.confluent.examples.streams
 import java.util
 import java.util.Properties
 
+import io.confluent.examples.streams.IntegrationTestUtils.NothingSerde
 import io.confluent.examples.streams.algebird.{CMSStore, CMSStoreBuilder, ProbabilisticCounter}
-import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster
-import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization._
+import org.apache.kafka.streams._
 import org.apache.kafka.streams.kstream.{KStream, Produced, TransformerSupplier}
-import org.apache.kafka.streams.{KafkaStreams, KeyValue, StreamsBuilder, StreamsConfig}
 import org.apache.kafka.test.TestUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit._
 import org.scalatest.junit.AssertionsForJUnit
+
+import scala.collection.JavaConverters._
 
 /**
   * End-to-end integration test that demonstrates how to probabilistically count items in an input stream.
@@ -38,23 +38,12 @@ import org.scalatest.junit.AssertionsForJUnit
   */
 class ProbabilisticCountingScalaIntegrationTest extends AssertionsForJUnit {
 
-  private val privateCluster: EmbeddedSingleNodeKafkaCluster = new EmbeddedSingleNodeKafkaCluster
-
-  @Rule def cluster: EmbeddedSingleNodeKafkaCluster = privateCluster
-
   private val inputTopic = "inputTopic"
   private val outputTopic = "output-topic"
-
-  @Before
-  def startKafkaCluster() {
-    cluster.createTopic(inputTopic)
-    cluster.createTopic(outputTopic)
-  }
 
   @Test
   def shouldProbabilisticallyCountWords() {
     // To convert between Scala's `Tuple2` and Streams' `KeyValue`.
-    import KeyValueImplicits._
 
     val inputTextLines: Seq[String] = Seq(
       "Hello Kafka Streams",
@@ -62,7 +51,7 @@ class ProbabilisticCountingScalaIntegrationTest extends AssertionsForJUnit {
       "Join Kafka Summit"
     )
 
-    val expectedWordCounts: Seq[KeyValue[String, Long]] = Seq(
+    val expectedWordCounts: Map[String, Long] = Map(
       ("hello", 1L),
       ("kafka", 1L),
       ("streams", 1L),
@@ -82,13 +71,9 @@ class ProbabilisticCountingScalaIntegrationTest extends AssertionsForJUnit {
     val streamsConfiguration: Properties = {
       val p = new Properties()
       p.put(StreamsConfig.APPLICATION_ID_CONFIG, "probabilistic-counting-scala-integration-test")
-      p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers())
+      p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config")
       p.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArray.getClass.getName)
       p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
-      // The commit interval for flushing records to state stores and downstream must be lower than
-      // this integration test's timeout (30 secs) to ensure we observe the expected processing results.
-      p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "10000")
-      p.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
       // Use a temporary directory for storing state, which will be automatically removed after the test.
       p.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory.getAbsolutePath)
       p
@@ -99,63 +84,52 @@ class ProbabilisticCountingScalaIntegrationTest extends AssertionsForJUnit {
     builder.addStateStore(createCMSStoreBuilder(cmsStoreName))
 
     // Read the input from Kafka.
-    val textLines: KStream[Array[Byte], String] = builder.stream(inputTopic)
+    val textLines: KStream[String, String] = builder.stream(inputTopic)
 
     // Scala-Java interoperability: to convert `scala.collection.Iterable` to  `java.util.Iterable`
     // in `flatMapValues()` below.
     import collection.JavaConverters.asJavaIterableConverter
 
     val approximateWordCounts: KStream[String, Long] = textLines
-        .flatMapValues(textLine => textLine.toLowerCase.split("\\W+").toIterable.asJava)
-        .transform(
-          new TransformerSupplier[Array[Byte], String, KeyValue[String, Long]] {
-            override def get() = new ProbabilisticCounter(cmsStoreName)
-          },
-          cmsStoreName)
+      .flatMapValues(textLine => textLine.toLowerCase.split("\\W+").toIterable.asJava)
+      .transform(
+        new TransformerSupplier[String, String, KeyValue[String, Long]] {
+          override def get() = new ProbabilisticCounter(cmsStoreName)
+        },
+        cmsStoreName)
 
     // Trick to re-use Kafka's serde for java.lang.Long for scala.Long.
     val longSerde: Serde[Long] = Serdes.Long().asInstanceOf[Serde[Long]]
     // Write the results back to Kafka.
     approximateWordCounts.to(outputTopic, Produced.`with`(Serdes.String(), longSerde))
 
-    val streams: KafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration)
-    streams.start()
+    val topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration)
 
-    //
-    // Step 2: Publish some input text lines.
-    //
-    val producerConfig: Properties = {
-      val p = new Properties()
-      p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers())
-      p.put(ProducerConfig.ACKS_CONFIG, "all")
-      p.put(ProducerConfig.RETRIES_CONFIG, "0")
-      p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer])
-      p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer])
-      p
+    try {
+      //
+      // Step 2: Publish some input text lines.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        inputTopic,
+        inputTextLines.map(v => new KeyValue(null, v)).asJava,
+        topologyTestDriver,
+        new NothingSerde[Null],
+        new StringSerializer
+      )
+
+      //
+      // Step 3: Verify the application's output data.
+      //
+      val actualWordCounts =
+      IntegrationTestUtils.drainTableOutput(outputTopic, topologyTestDriver, new StringDeserializer, new LongDeserializer)
+
+      // Note: This example only processes a small amount of input data, for which the word counts
+      // will actually be exact counts.  However, for large amounts of input data we would expect to
+      // observe approximate counts (where the approximate counts would be >= true exact counts).
+      assertThat(actualWordCounts).isEqualTo(expectedWordCounts.asJava)
+    } finally {
+      topologyTestDriver.close()
     }
-    import collection.JavaConverters._
-    IntegrationTestUtils.produceValuesSynchronously(inputTopic, inputTextLines.asJava, producerConfig)
-
-    //
-    // Step 3: Verify the application's output data.
-    //
-    val consumerConfig = {
-      val p = new Properties()
-      p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers())
-      p.put(ConsumerConfig.GROUP_ID_CONFIG, "probabilistic-counting-consumer")
-      p.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-      p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer])
-      p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[LongDeserializer])
-      p
-    }
-    val actualWordCounts: java.util.List[KeyValue[String, Long]] =
-      IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerConfig, outputTopic, expectedWordCounts.size)
-    streams.close()
-
-    // Note: This example only processes a small amount of input data, for which the word counts
-    // will actually be exact counts.  However, for large amounts of input data we would expect to
-    // observe approximate counts (where the approximate counts would be >= true exact counts).
-    assertThat(actualWordCounts).containsExactlyElementsOf(expectedWordCounts.asJava)
   }
 
   private def createCMSStoreBuilder(cmsStoreName: String): CMSStoreBuilder[String] = {
@@ -168,7 +142,7 @@ class ProbabilisticCountingScalaIntegrationTest extends AssertionsForJUnit {
       cfg
     }
     new CMSStoreBuilder[String](cmsStoreName, Serdes.String())
-        .withLoggingEnabled(changelogConfig)
+      .withLoggingEnabled(changelogConfig)
   }
 
 }

--- a/src/test/scala/io/confluent/examples/streams/StreamToTableJoinScalaIntegrationTest.scala
+++ b/src/test/scala/io/confluent/examples/streams/StreamToTableJoinScalaIntegrationTest.scala
@@ -21,8 +21,8 @@ import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization._
-import org.apache.kafka.streams.kstream.{KStream, KTable, Produced, Serialized}
 import org.apache.kafka.streams._
+import org.apache.kafka.streams.kstream.{KStream, KTable, Produced, Serialized}
 import org.apache.kafka.test.TestUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit._
@@ -85,7 +85,7 @@ class StreamToTableJoinScalaIntegrationTest extends AssertionsForJUnit {
       ("fang", "asia")
     )
 
-    val expectedClicksPerRegion: Seq[KeyValue[String, Long]] = Seq(
+    val expectedClicksPerRegion: Map[String, Long] = Map(
       ("americas", 101L),
       ("europe", 109L),
       ("asia", 124L)
@@ -108,13 +108,9 @@ class StreamToTableJoinScalaIntegrationTest extends AssertionsForJUnit {
     val streamsConfiguration: Properties = {
       val p = new Properties()
       p.put(StreamsConfig.APPLICATION_ID_CONFIG, "stream-table-join-scala-integration-test")
-      p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers())
+      p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config")
       p.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
       p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
-      // The commit interval for flushing records to state stores and downstream must be lower than
-      // this integration test's timeout (30 secs) to ensure we observe the expected processing results.
-      p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "10000")
-      p.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
       // Use a temporary directory for storing state, which will be automatically removed after the test.
       p.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory.getAbsolutePath)
       p
@@ -145,7 +141,7 @@ class StreamToTableJoinScalaIntegrationTest extends AssertionsForJUnit {
     //
     // The resulting KTable is continuously being updated as new data records are arriving in the
     // input KStream `userClicksStream` and input KTable `userRegionsTable`.
-    val userClicksJoinRegion : KStream[String, (String, Long)] = userClicksStream
+    val userClicksJoinRegion: KStream[String, (String, Long)] = userClicksStream
       // Join the stream against the table.
       //
       // Null values possible: In general, null values are possible for region (i.e. the value of
@@ -154,70 +150,80 @@ class StreamToTableJoinScalaIntegrationTest extends AssertionsForJUnit {
       // we know, based on the test setup, that all users have appropriate region entries at the
       // time we perform the join.
       .leftJoin(userRegionsTable, (clicks: Long, region: String) => (if (region == null) "UNKNOWN" else region, clicks))
-    val clicksByRegion : KStream[String, Long] = userClicksJoinRegion
+    val clicksByRegion: KStream[String, Long] = userClicksJoinRegion
       // Change the stream from <user> -> <region, clicks> to <region> -> <clicks>
       .map((_: String, regionWithClicks: (String, Long)) => new KeyValue[String, Long](
       regionWithClicks._1, regionWithClicks._2))
 
     val clicksPerRegion: KTable[String, Long] = clicksByRegion
-        // Compute the total per region by summing the individual click counts per region.
-        .groupByKey(Serialized.`with`(stringSerde, longSerde))
-        .reduce(_ + _)
+      // Compute the total per region by summing the individual click counts per region.
+      .groupByKey(Serialized.`with`(stringSerde, longSerde))
+      .reduce(_ + _)
 
     // Write the (continuously updating) results to the output topic.
     clicksPerRegion.toStream().to(outputTopic, Produced.`with`(stringSerde, longSerde))
 
-    val streams: KafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration)
-    streams.start()
+    val topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration)
 
-    //
-    // Step 2: Publish user-region information.
-    //
-    // To keep this code example simple and easier to understand/reason about, we publish all
-    // user-region records before any user-click records (cf. step 3).  In practice though,
-    // data records would typically be arriving concurrently in both input streams/topics.
-    val userRegionsProducerConfig: Properties = {
-      val p = new Properties()
-      p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers())
-      p.put(ProducerConfig.ACKS_CONFIG, "all")
-      p.put(ProducerConfig.RETRIES_CONFIG, "0")
-      p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer])
-      p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer])
-      p
-    }
-    import collection.JavaConverters._
-    IntegrationTestUtils.produceKeyValuesSynchronously(userRegionsTopic, userRegions.asJava, userRegionsProducerConfig)
+    try {
+      //
+      // Step 2: Publish user-region information.
+      //
+      // To keep this code example simple and easier to understand/reason about, we publish all
+      // user-region records before any user-click records (cf. step 3).  In practice though,
+      // data records would typically be arriving concurrently in both input streams/topics.
+      val userRegionsProducerConfig: Properties = {
+        val p = new Properties()
+        p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers())
+        p.put(ProducerConfig.ACKS_CONFIG, "all")
+        p.put(ProducerConfig.RETRIES_CONFIG, "0")
+        p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer])
+        p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer])
+        p
+      }
+      import collection.JavaConverters._
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        userRegionsTopic,
+        userRegions.asJava,
+        topologyTestDriver,
+        new StringSerializer,
+        new StringSerializer
+      )
 
-    //
-    // Step 3: Publish some user click events.
-    //
-    val userClicksProducerConfig: Properties = {
-      val p = new Properties()
-      p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers())
-      p.put(ProducerConfig.ACKS_CONFIG, "all")
-      p.put(ProducerConfig.RETRIES_CONFIG, "0")
-      p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer])
-      p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[LongSerializer])
-      p
-    }
-    IntegrationTestUtils.produceKeyValuesSynchronously(userClicksTopic, userClicks.asJava, userClicksProducerConfig)
+      //
+      // Step 3: Publish some user click events.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        userClicksTopic,
+        userClicks.map(kv => new KeyValue(kv.key, kv.value.asInstanceOf[java.lang.Long])).asJava,
+        topologyTestDriver,
+        new StringSerializer,
+        new LongSerializer
+      )
 
-    //
-    // Step 4: Verify the application's output data.
-    //
-    val consumerConfig = {
-      val p = new Properties()
-      p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers())
-      p.put(ConsumerConfig.GROUP_ID_CONFIG, "join-scala-integration-test-standard-consumer")
-      p.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-      p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer])
-      p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[LongDeserializer])
-      p
+      //
+      // Step 4: Verify the application's output data.
+      //
+      val consumerConfig = {
+        val p = new Properties()
+        p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers())
+        p.put(ConsumerConfig.GROUP_ID_CONFIG, "join-scala-integration-test-standard-consumer")
+        p.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+        p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer])
+        p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[LongDeserializer])
+        p
+      }
+      val actualClicksPerRegion =
+        IntegrationTestUtils.drainTableOutput(
+          outputTopic,
+          topologyTestDriver,
+          new StringDeserializer,
+          new LongDeserializer
+        )
+      assertThat(actualClicksPerRegion).isEqualTo(expectedClicksPerRegion.asJava)
+    } finally {
+      topologyTestDriver.close()
     }
-    val actualClicksPerRegion: java.util.List[KeyValue[String, Long]] = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerConfig,
-      outputTopic, expectedClicksPerRegion.size)
-    streams.close()
-    assertThat(actualClicksPerRegion).containsExactlyElementsOf(expectedClicksPerRegion.asJava)
   }
 
 }

--- a/src/test/scala/io/confluent/examples/streams/WordCountScalaIntegrationTest.scala
+++ b/src/test/scala/io/confluent/examples/streams/WordCountScalaIntegrationTest.scala
@@ -18,16 +18,16 @@ package io.confluent.examples.streams
 import java.lang.{Long => JLong}
 import java.util.Properties
 
-import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster
-import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.clients.producer.ProducerConfig
+import io.confluent.examples.streams.IntegrationTestUtils.NothingSerde
 import org.apache.kafka.common.serialization._
+import org.apache.kafka.streams._
 import org.apache.kafka.streams.kstream.{KStream, KTable, Produced}
-import org.apache.kafka.streams.{KafkaStreams, KeyValue, StreamsBuilder, StreamsConfig}
 import org.apache.kafka.test.TestUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit._
 import org.scalatest.junit.AssertionsForJUnit
+
+import scala.collection.JavaConverters._
 
 /**
   * End-to-end integration test based on [[WordCountLambdaExample]], using an embedded Kafka cluster.
@@ -44,23 +44,12 @@ import org.scalatest.junit.AssertionsForJUnit
   */
 class WordCountScalaIntegrationTest extends AssertionsForJUnit {
 
-  private val privateCluster: EmbeddedSingleNodeKafkaCluster = new EmbeddedSingleNodeKafkaCluster
-
-  @Rule def cluster: EmbeddedSingleNodeKafkaCluster = privateCluster
-
   private val inputTopic = "inputTopic"
   private val outputTopic = "output-topic"
-
-  @Before
-  def startKafkaCluster() {
-    cluster.createTopic(inputTopic)
-    cluster.createTopic(outputTopic)
-  }
 
   @Test
   def shouldCountWords() {
     // To convert between Scala's `Tuple2` and Streams' `KeyValue`.
-    import KeyValueImplicits._
 
     val inputTextLines: Seq[String] = Seq(
       "Hello Kafka Streams",
@@ -68,7 +57,7 @@ class WordCountScalaIntegrationTest extends AssertionsForJUnit {
       "Join Kafka Summit"
     )
 
-    val expectedWordCounts: Seq[KeyValue[String, Long]] = Seq(
+    val expectedWordCounts: Map[String, Long] = Map(
       ("hello", 1L),
       ("all", 1L),
       ("streams", 2L),
@@ -85,13 +74,9 @@ class WordCountScalaIntegrationTest extends AssertionsForJUnit {
     val streamsConfiguration: Properties = {
       val p = new Properties()
       p.put(StreamsConfig.APPLICATION_ID_CONFIG, "wordcount-scala-integration-test")
-      p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers())
+      p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config")
       p.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
       p.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String.getClass.getName)
-      // The commit interval for flushing records to state stores and downstream must be lower than
-      // this integration test's timeout (30 secs) to ensure we observe the expected processing results.
-      p.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "10000")
-      p.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
       // Use a temporary directory for storing state, which will be automatically removed after the test.
       p.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory.getAbsolutePath)
       p
@@ -111,47 +96,36 @@ class WordCountScalaIntegrationTest extends AssertionsForJUnit {
     import collection.JavaConverters.asJavaIterableConverter
 
     val wordCounts: KTable[String, JLong] = textLines
-        .flatMapValues(value => value.toLowerCase.split("\\W+").toIterable.asJava)
-        // no need to specify explicit serdes because the resulting key and value types match our default serde settings
-        .groupBy((_, word) => word)
-        .count()
+      .flatMapValues(value => value.toLowerCase.split("\\W+").toIterable.asJava)
+      // no need to specify explicit serdes because the resulting key and value types match our default serde settings
+      .groupBy((_, word) => word)
+      .count()
 
     wordCounts.toStream.to(outputTopic, Produced.`with`(stringSerde, longSerde))
 
-    val streams: KafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration)
-    streams.start()
+    val topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration)
 
-    //
-    // Step 2: Publish some input text lines.
-    //
-    val producerConfig: Properties = {
-      val p = new Properties()
-      p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers())
-      p.put(ProducerConfig.ACKS_CONFIG, "all")
-      p.put(ProducerConfig.RETRIES_CONFIG, "0")
-      p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer])
-      p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer])
-      p
-    }
-    import collection.JavaConverters._
-    IntegrationTestUtils.produceValuesSynchronously(inputTopic, inputTextLines.asJava, producerConfig)
+    try {
+      //
+      // Step 2: Publish some input text lines.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        inputTopic,
+        inputTextLines.map(v => new KeyValue(null, v)).asJava,
+        topologyTestDriver,
+        new NothingSerde[Null],
+        new StringSerializer
+      )
 
-    //
-    // Step 3: Verify the application's output data.
-    //
-    val consumerConfig = {
-      val p = new Properties()
-      p.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers())
-      p.put(ConsumerConfig.GROUP_ID_CONFIG, "wordcount-scala-integration-test-standard-consumer")
-      p.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-      p.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer])
-      p.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[LongDeserializer])
-      p
+      //
+      // Step 3: Verify the application's output data.
+      //
+      val actualWordCounts =
+      IntegrationTestUtils.drainTableOutput(outputTopic, topologyTestDriver, new StringDeserializer, new LongDeserializer)
+      assertThat(actualWordCounts).isEqualTo(expectedWordCounts.asJava)
+    } finally {
+      topologyTestDriver.close()
     }
-    val actualWordCounts: java.util.List[KeyValue[String, Long]] =
-      IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerConfig, outputTopic, expectedWordCounts.size)
-    streams.close()
-    assertThat(actualWordCounts).containsExactlyElementsOf(expectedWordCounts.asJava)
   }
 
 }


### PR DESCRIPTION
Continue the work of #242 , #245 , and #246 by porting the rest of the integration tests that don't use Schema Registry.

The Schema Registry tests will get ported in a later PR.