### PR TITLE
MINOR: Block on streams start until in a RUNNING state

### DIFF
--- a/src/main/java/io/confluent/examples/streams/microservices/EmailService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/EmailService.java
@@ -52,11 +52,8 @@ public class EmailService implements Service {
 
     });
     streams.start();
-    final boolean rebalanceCompleted;
-
     try {
-      rebalanceCompleted = startLatch.await(60, TimeUnit.SECONDS);
-      if (!rebalanceCompleted) {
+      if (!startLatch.await(60, TimeUnit.SECONDS)) {
         throw new RuntimeException("Streams never finished rebalancing on startup");
       }
     } catch (final InterruptedException e) {

--- a/src/main/java/io/confluent/examples/streams/microservices/EmailService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/EmailService.java
@@ -11,7 +11,11 @@ import static io.confluent.examples.streams.microservices.util.MicroserviceUtils
 import io.confluent.examples.streams.avro.microservices.Customer;
 import io.confluent.examples.streams.avro.microservices.Order;
 import io.confluent.examples.streams.avro.microservices.Payment;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.KafkaStreams.StateListener;
 import org.apache.kafka.streams.kstream.GlobalKTable;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.KStream;
@@ -40,7 +44,24 @@ public class EmailService implements Service {
   public void start(final String bootstrapServers) {
     streams = processStreams(bootstrapServers, "/tmp/kafka-streams");
     streams.cleanUp(); //don't do this in prod as it clears your state stores
+    final CountDownLatch startLatch = new CountDownLatch(1);
+    streams.setStateListener((newState, oldState) -> {
+      if (newState == State.RUNNING && oldState == State.REBALANCING) {
+        startLatch.countDown();
+      }
+
+    });
     streams.start();
+    final boolean rebalanceCompleted;
+
+    try {
+      rebalanceCompleted = startLatch.await(60, TimeUnit.SECONDS);
+      if (!rebalanceCompleted) {
+        throw new RuntimeException("Streams never finished rebalancing on startup");
+      }
+    } catch (final InterruptedException e) {
+       Thread.currentThread().interrupt();
+    }
     log.info("Started Service " + APP_ID);
   }
 

--- a/src/main/java/io/confluent/examples/streams/microservices/FraudService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/FraudService.java
@@ -5,8 +5,11 @@ import io.confluent.examples.streams.avro.microservices.OrderState;
 import io.confluent.examples.streams.avro.microservices.OrderValidation;
 import io.confluent.examples.streams.avro.microservices.OrderValue;
 import io.confluent.examples.streams.microservices.domain.Schemas;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KStreamBuilder;
@@ -17,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
+import scala.Int;
 
 import static io.confluent.examples.streams.avro.microservices.OrderValidationResult.FAIL;
 import static io.confluent.examples.streams.avro.microservices.OrderValidationResult.PASS;
@@ -46,7 +50,25 @@ public class FraudService implements Service {
   public void start(final String bootstrapServers) {
     streams = processStreams(bootstrapServers, "/tmp/kafka-streams");
     streams.cleanUp(); //don't do this in prod as it clears your state stores
+    final CountDownLatch startLatch = new CountDownLatch(1);
+    streams.setStateListener((newState, oldState) -> {
+      if (newState == State.RUNNING && oldState == State.REBALANCING) {
+        startLatch.countDown();
+      }
+
+    });
     streams.start();
+    final boolean rebalanceCompleted;
+
+    try {
+      rebalanceCompleted = startLatch.await(60, TimeUnit.SECONDS);
+      if (!rebalanceCompleted) {
+        throw new RuntimeException("Streams never finished rebalancing on startup");
+      }
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+
     log.info("Started Service " + getClass().getSimpleName());
   }
 

--- a/src/main/java/io/confluent/examples/streams/microservices/FraudService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/FraudService.java
@@ -58,11 +58,9 @@ public class FraudService implements Service {
 
     });
     streams.start();
-    final boolean rebalanceCompleted;
 
     try {
-      rebalanceCompleted = startLatch.await(60, TimeUnit.SECONDS);
-      if (!rebalanceCompleted) {
+      if (!startLatch.await(60, TimeUnit.SECONDS)) {
         throw new RuntimeException("Streams never finished rebalancing on startup");
       }
     } catch (final InterruptedException e) {

--- a/src/main/java/io/confluent/examples/streams/microservices/InventoryService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/InventoryService.java
@@ -58,11 +58,9 @@ public class InventoryService implements Service {
 
     });
     streams.start();
-    final boolean rebalanceCompleted;
 
     try {
-      rebalanceCompleted = startLatch.await(60, TimeUnit.SECONDS);
-      if (!rebalanceCompleted) {
+      if (!startLatch.await(60, TimeUnit.SECONDS)) {
         throw new RuntimeException("Streams never finished rebalancing on startup");
       }
     } catch (final InterruptedException e) {

--- a/src/main/java/io/confluent/examples/streams/microservices/InventoryService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/InventoryService.java
@@ -12,8 +12,11 @@ import io.confluent.examples.streams.avro.microservices.OrderValidation;
 import io.confluent.examples.streams.avro.microservices.Product;
 import io.confluent.examples.streams.microservices.domain.Schemas.Topics;
 import io.confluent.examples.streams.microservices.util.MicroserviceUtils;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KStreamBuilder;
@@ -47,7 +50,24 @@ public class InventoryService implements Service {
   public void start(final String bootstrapServers) {
     streams = processStreams(bootstrapServers, "/tmp/kafka-streams");
     streams.cleanUp(); //don't do this in prod as it clears your state stores
+    final CountDownLatch startLatch = new CountDownLatch(1);
+    streams.setStateListener((newState, oldState) -> {
+      if (newState == State.RUNNING && oldState == State.REBALANCING) {
+        startLatch.countDown();
+      }
+
+    });
     streams.start();
+    final boolean rebalanceCompleted;
+
+    try {
+      rebalanceCompleted = startLatch.await(60, TimeUnit.SECONDS);
+      if (!rebalanceCompleted) {
+        throw new RuntimeException("Streams never finished rebalancing on startup");
+      }
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
     log.info("Started Service " + getClass().getSimpleName());
   }
 

--- a/src/main/java/io/confluent/examples/streams/microservices/OrdersService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/OrdersService.java
@@ -333,11 +333,9 @@ public class OrdersService implements Service {
 
     });
     streams.start();
-    final boolean rebalanceCompleted;
 
     try {
-      rebalanceCompleted = startLatch.await(60, TimeUnit.SECONDS);
-      if (!rebalanceCompleted) {
+      if (!startLatch.await(60, TimeUnit.SECONDS)) {
         throw new RuntimeException("Streams never finished rebalancing on startup");
       }
     } catch (final InterruptedException e) {

--- a/src/main/java/io/confluent/examples/streams/microservices/OrdersService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/OrdersService.java
@@ -7,11 +7,14 @@ import io.confluent.examples.streams.interactivequeries.MetadataService;
 import io.confluent.examples.streams.microservices.domain.Schemas;
 import io.confluent.examples.streams.microservices.domain.beans.OrderBean;
 import io.confluent.examples.streams.microservices.util.Paths;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.kstream.KStreamBuilder;
@@ -322,7 +325,24 @@ public class OrdersService implements Service {
         config(bootstrapServers));
     metadataService = new MetadataService(streams);
     streams.cleanUp(); //don't do this in prod as it clears your state stores
+    final CountDownLatch startLatch = new CountDownLatch(1);
+    streams.setStateListener((newState, oldState) -> {
+      if (newState == State.RUNNING && oldState == State.REBALANCING) {
+        startLatch.countDown();
+      }
+
+    });
     streams.start();
+    final boolean rebalanceCompleted;
+
+    try {
+      rebalanceCompleted = startLatch.await(60, TimeUnit.SECONDS);
+      if (!rebalanceCompleted) {
+        throw new RuntimeException("Streams never finished rebalancing on startup");
+      }
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
     return streams;
   }
 


### PR DESCRIPTION
This PR is an attempt to help reduce the flakiness of some of the microservice tests.  From looking at the logs, it seems it may take a streams app some time to get into a running state, so the idea is to have the tests block until streams goes from `REBALANCING` to a `RUNNING` state

I'm targeting the `3.3.0-post` branch, so this will hit all versions we're responsible for keeping the tests green.