### PR TITLE
MINOR: migrate GenericAvroIntegrationTest to TTD

### DIFF
--- a/src/test/java/io/confluent/examples/streams/GenericAvroIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/GenericAvroIntegrationTest.java
@@ -15,7 +15,8 @@
  */
 package io.confluent.examples.streams;
 
-import io.confluent.examples.streams.kafka.EmbeddedSingleNodeKafkaCluster;
+import io.confluent.examples.streams.utils.MockGenericAvroSerde;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
@@ -24,49 +25,45 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Produced;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import static io.confluent.examples.streams.IntegrationTestUtils.mkEntry;
+import static io.confluent.examples.streams.IntegrationTestUtils.mkMap;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * End-to-end integration test that demonstrates how to work on Generic Avro data.
- *
+ * <p>
  * See {@link SpecificAvroIntegrationTest} for the equivalent Specific Avro integration test.
  */
 public class GenericAvroIntegrationTest {
 
-  @ClassRule
-  public static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster();
-
   private static String inputTopic = "inputTopic";
   private static String outputTopic = "outputTopic";
 
-  @BeforeClass
-  public static void startKafkaCluster() throws Exception {
-    CLUSTER.createTopic(inputTopic);
-    CLUSTER.createTopic(outputTopic);
-  }
-
   @Test
   public void shouldRoundTripGenericAvroDataThroughKafka() throws Exception {
+    final MockSchemaRegistryClient mockSchemaRegistryClient = new MockSchemaRegistryClient();
+
     final Schema schema = new Schema.Parser().parse(
-        getClass().getResourceAsStream("/avro/io/confluent/examples/streams/wikifeed.avsc"));
+      getClass().getResourceAsStream("/avro/io/confluent/examples/streams/wikifeed.avsc")
+    );
+
+    mockSchemaRegistryClient.register("inputTopic-value", schema);
+
     final GenericRecord record = new GenericData.Record(schema);
     record.put("user", "alice");
     record.put("is_new", true);
@@ -80,10 +77,11 @@ public class GenericAvroIntegrationTest {
 
     final Properties streamsConfiguration = new Properties();
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "generic-avro-integration-test");
-    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
     streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArray().getClass().getName());
-    streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, GenericAvroSerde.class);
-    streamsConfiguration.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, CLUSTER.schemaRegistryUrl());
+    streamsConfiguration.put("mock.schema.registry.client", mockSchemaRegistryClient);
+    streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, MockGenericAvroSerde.class);
+    streamsConfiguration.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "dummy config");
     streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
     // Write the input data as-is to the output topic.
@@ -97,46 +95,48 @@ public class GenericAvroIntegrationTest {
     // However, in the code below we intentionally override the default serdes in `to()` to
     // demonstrate how you can construct and configure a generic Avro serde manually.
     final Serde<String> stringSerde = Serdes.String();
-    final Serde<GenericRecord> genericAvroSerde = new GenericAvroSerde();
+    final Serde<GenericRecord> genericAvroSerde = new MockGenericAvroSerde();
     // Note how we must manually call `configure()` on this serde to configure the schema registry
     // url.  This is different from the case of setting default serdes (see `streamsConfiguration`
     // above), which will be auto-configured based on the `StreamsConfiguration` instance.
-    final boolean isKeySerde = false;
     genericAvroSerde.configure(
-        Collections.singletonMap(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, CLUSTER.schemaRegistryUrl()),
-        isKeySerde);
+        mkMap(
+          mkEntry("mock.schema.registry.client", mockSchemaRegistryClient),
+          mkEntry(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "dummy config")
+        ),
+        /*isKey*/ false);
     final KStream<String, GenericRecord> stream = builder.stream(inputTopic);
     stream.to(outputTopic, Produced.with(stringSerde, genericAvroSerde));
 
-    final KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfiguration);
-    streams.start();
 
-    //
-    // Step 2: Produce some input data to the input topic.
-    //
-    final Properties producerConfig = new Properties();
-    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
-    producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
-    producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class);
-    producerConfig.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, CLUSTER.schemaRegistryUrl());
-    IntegrationTestUtils.produceValuesSynchronously(inputTopic, inputValues, producerConfig);
+    final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration);
 
-    //
-    // Step 3: Verify the application's output data.
-    //
-    final Properties consumerConfig = new Properties();
-    consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "generic-avro-integration-test-standard-consumer");
-    consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-    consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-    consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class);
-    consumerConfig.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, CLUSTER.schemaRegistryUrl());
-    final List<GenericRecord> actualValues = IntegrationTestUtils.waitUntilMinValuesRecordsReceived(consumerConfig,
-        outputTopic, inputValues.size());
-    streams.close();
-    assertEquals(inputValues, actualValues);
+    try {
+
+      //
+      // Step 2: Produce some input data to the input topic.
+      //
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        inputTopic,
+        inputValues.stream().map(v -> new KeyValue<>(null, (Object) v)).collect(Collectors.toList()),
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new KafkaAvroSerializer(mockSchemaRegistryClient)
+      );
+
+      //
+      // Step 3: Verify the application's output data.
+      //
+      final List<GenericRecord> actualValues = IntegrationTestUtils.drainStreamOutput(
+        outputTopic,
+        topologyTestDriver,
+        new IntegrationTestUtils.NothingSerde<>(),
+        new KafkaAvroDeserializer(mockSchemaRegistryClient)
+      ).stream().map(kv -> (GenericRecord) kv.value).collect(Collectors.toList());
+      assertThat(actualValues).isEqualTo(inputValues);
+    } finally {
+      topologyTestDriver.close();
+    }
   }
 
 }

--- a/src/test/java/io/confluent/examples/streams/GenericAvroIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/GenericAvroIntegrationTest.java
@@ -95,15 +95,12 @@ public class GenericAvroIntegrationTest {
     // However, in the code below we intentionally override the default serdes in `to()` to
     // demonstrate how you can construct and configure a generic Avro serde manually.
     final Serde<String> stringSerde = Serdes.String();
-    final Serde<GenericRecord> genericAvroSerde = new MockGenericAvroSerde();
+    final Serde<GenericRecord> genericAvroSerde = new MockGenericAvroSerde(mockSchemaRegistryClient);
     // Note how we must manually call `configure()` on this serde to configure the schema registry
     // url.  This is different from the case of setting default serdes (see `streamsConfiguration`
     // above), which will be auto-configured based on the `StreamsConfiguration` instance.
     genericAvroSerde.configure(
-        mkMap(
-          mkEntry("mock.schema.registry.client", mockSchemaRegistryClient),
-          mkEntry(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "dummy config")
-        ),
+        Collections.singletonMap(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "dummy config"),
         /*isKey*/ false);
     final KStream<String, GenericRecord> stream = builder.stream(inputTopic);
     stream.to(outputTopic, Produced.with(stringSerde, genericAvroSerde));

--- a/src/test/java/io/confluent/examples/streams/utils/MockGenericAvroDeserializer.java
+++ b/src/test/java/io/confluent/examples/streams/utils/MockGenericAvroDeserializer.java
@@ -9,12 +9,24 @@ import java.util.Map;
 
 public class MockGenericAvroDeserializer implements Deserializer<GenericRecord> {
   private KafkaAvroDeserializer inner;
+  private final boolean constructedWithClient;
+
+  MockGenericAvroDeserializer() {
+    constructedWithClient = false;
+  }
+
+  MockGenericAvroDeserializer(final MockSchemaRegistryClient mockSchemaRegistryClient) {
+    inner = new KafkaAvroDeserializer(mockSchemaRegistryClient);
+    constructedWithClient = true;
+  }
 
   @Override
   public void configure(final Map<String, ?> configs, final boolean isKey) {
-    final MockSchemaRegistryClient mockSchemaRegistryClient =
-      (MockSchemaRegistryClient) configs.get("mock.schema.registry.client");
-    inner = new KafkaAvroDeserializer(mockSchemaRegistryClient);
+    if (!constructedWithClient) {
+      final MockSchemaRegistryClient mockSchemaRegistryClient =
+        (MockSchemaRegistryClient) configs.get("mock.schema.registry.client");
+      inner = new KafkaAvroDeserializer(mockSchemaRegistryClient);
+    }
     inner.configure(configs, isKey);
   }
 

--- a/src/test/java/io/confluent/examples/streams/utils/MockGenericAvroDeserializer.java
+++ b/src/test/java/io/confluent/examples/streams/utils/MockGenericAvroDeserializer.java
@@ -1,0 +1,30 @@
+package io.confluent.examples.streams.utils;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.util.Map;
+
+public class MockGenericAvroDeserializer implements Deserializer<GenericRecord> {
+  private KafkaAvroDeserializer inner;
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+    final MockSchemaRegistryClient mockSchemaRegistryClient =
+      (MockSchemaRegistryClient) configs.get("mock.schema.registry.client");
+    inner = new KafkaAvroDeserializer(mockSchemaRegistryClient);
+    inner.configure(configs, isKey);
+  }
+
+  @Override
+  public GenericRecord deserialize(final String topic, final byte[] data) {
+    return (GenericRecord) inner.deserialize(topic, data);
+  }
+
+  @Override
+  public void close() {
+    inner.close();
+  }
+}

--- a/src/test/java/io/confluent/examples/streams/utils/MockGenericAvroSerde.java
+++ b/src/test/java/io/confluent/examples/streams/utils/MockGenericAvroSerde.java
@@ -1,0 +1,40 @@
+package io.confluent.examples.streams.utils;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.Map;
+
+public class MockGenericAvroSerde implements Serde<GenericRecord> {
+  private final MockGenericAvroSerializer serializer;
+  private final MockGenericAvroDeserializer deserializer;
+
+  public MockGenericAvroSerde() {
+    serializer = new MockGenericAvroSerializer();
+    deserializer = new MockGenericAvroDeserializer();
+  }
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+    serializer.configure(configs, isKey);
+    deserializer.configure(configs, isKey);
+  }
+
+  @Override
+  public void close() {
+    serializer.close();
+    deserializer.close();
+  }
+
+  @Override
+  public Serializer<GenericRecord> serializer() {
+    return serializer;
+  }
+
+  @Override
+  public Deserializer<GenericRecord> deserializer() {
+    return deserializer;
+  }
+}

--- a/src/test/java/io/confluent/examples/streams/utils/MockGenericAvroSerde.java
+++ b/src/test/java/io/confluent/examples/streams/utils/MockGenericAvroSerde.java
@@ -1,5 +1,6 @@
 package io.confluent.examples.streams.utils;
 
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
@@ -14,6 +15,11 @@ public class MockGenericAvroSerde implements Serde<GenericRecord> {
   public MockGenericAvroSerde() {
     serializer = new MockGenericAvroSerializer();
     deserializer = new MockGenericAvroDeserializer();
+  }
+
+  public MockGenericAvroSerde(final MockSchemaRegistryClient mockSchemaRegistryClient) {
+    serializer = new MockGenericAvroSerializer(mockSchemaRegistryClient);
+    deserializer = new MockGenericAvroDeserializer(mockSchemaRegistryClient);
   }
 
   @Override

--- a/src/test/java/io/confluent/examples/streams/utils/MockGenericAvroSerializer.java
+++ b/src/test/java/io/confluent/examples/streams/utils/MockGenericAvroSerializer.java
@@ -1,0 +1,30 @@
+package io.confluent.examples.streams.utils;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.Map;
+
+public class MockGenericAvroSerializer implements Serializer<GenericRecord> {
+  private KafkaAvroSerializer inner;
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+    final MockSchemaRegistryClient mockSchemaRegistryClient =
+      (MockSchemaRegistryClient) configs.get("mock.schema.registry.client");
+    inner = new KafkaAvroSerializer(mockSchemaRegistryClient);
+    inner.configure(configs, isKey);
+  }
+
+  @Override
+  public byte[] serialize(final String topic, final GenericRecord data) {
+    return inner.serialize(topic, data);
+  }
+
+  @Override
+  public void close() {
+    inner.close();
+  }
+}

--- a/src/test/java/io/confluent/examples/streams/utils/MockGenericAvroSerializer.java
+++ b/src/test/java/io/confluent/examples/streams/utils/MockGenericAvroSerializer.java
@@ -9,12 +9,24 @@ import java.util.Map;
 
 public class MockGenericAvroSerializer implements Serializer<GenericRecord> {
   private KafkaAvroSerializer inner;
+  private final boolean constructedWithClient;
+
+  MockGenericAvroSerializer() {
+    constructedWithClient = false;
+  }
+
+  MockGenericAvroSerializer(final MockSchemaRegistryClient mockSchemaRegistryClient) {
+    inner = new KafkaAvroSerializer(mockSchemaRegistryClient);
+    constructedWithClient = true;
+  }
 
   @Override
   public void configure(final Map<String, ?> configs, final boolean isKey) {
-    final MockSchemaRegistryClient mockSchemaRegistryClient =
-      (MockSchemaRegistryClient) configs.get("mock.schema.registry.client");
-    inner = new KafkaAvroSerializer(mockSchemaRegistryClient);
+    if (!constructedWithClient) {
+      final MockSchemaRegistryClient mockSchemaRegistryClient =
+        (MockSchemaRegistryClient) configs.get("mock.schema.registry.client");
+      inner = new KafkaAvroSerializer(mockSchemaRegistryClient);
+    }
     inner.configure(configs, isKey);
   }
 


### PR DESCRIPTION
Continue the work of #242 , #245 , #246 , and #248 by establishing a pattern for GenericRecord Avro tests to use TopologyTestDriver.