### PR TITLE
KSTREAMS-2871, KSTREAMS-2870, KSTREAMS-2868: Fix test failures

### DIFF
--- a/src/main/java/io/confluent/examples/streams/WordCountLambdaExample.java
+++ b/src/main/java/io/confluent/examples/streams/WordCountLambdaExample.java
@@ -15,6 +15,7 @@
  */
 package io.confluent.examples.streams;
 
+import io.confluent.common.utils.TestUtils;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -171,6 +172,8 @@ public class WordCountLambdaExample {
     streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 10 * 1000);
     // For illustrative purposes we disable record caches.
     streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+    // Use a temporary directory for storing state, which will be automatically removed after the test.
+    streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
     return streamsConfiguration;
   }
 


### PR DESCRIPTION
- Changed handling of result of `get` on user-defined store since
   stores return a value and a timestamp since 2.3
- Set STATE_DIR_CONFIG to temp directory.