### PR TITLE
MINOR: Change set vs seq for java converters

### DIFF
--- a/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
+++ b/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
@@ -253,6 +253,9 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     @Override
     public boolean conditionMet() {
       //TODO once KAFKA-6098 is fixed use AdminClient to verify topics have been deleted
+
+      // The Set returned from JavaConverters.setAsJavaSetConverter does not support the remove
+      // method so we need to continue to wrap in a HashSet
       final Set<String> allTopics = new HashSet<>(
           JavaConverters.setAsJavaSetConverter(broker.kafkaServer().zkClient().getAllTopicsInCluster()).asJava());
       return !allTopics.removeAll(deletedTopics);

--- a/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
+++ b/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
@@ -254,7 +254,7 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     public boolean conditionMet() {
       //TODO once KAFKA-6098 is fixed use AdminClient to verify topics have been deleted
       final Set<String> allTopics = new HashSet<>(
-          JavaConverters.seqAsJavaListConverter(broker.kafkaServer().zkClient().getAllTopicsInCluster()).asJava());
+          JavaConverters.setAsJavaSetConverter(broker.kafkaServer().zkClient().getAllTopicsInCluster()).asJava());
       return !allTopics.removeAll(deletedTopics);
     }
   }


### PR DESCRIPTION
The `KafkaZkClient` now returns a `Set` instead of a `Seq` for `getAllTopicsInCluster` so we needed to switch to `JavaConverters.setAsJavaSetConverter` method