### PR TITLE
Use |release| macro for branch name in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ Ready now?  Let's start!
 
 Clone the Confluent Docker Images repository:
 
-  .. sourcecode:: bash
+  .. codewithvars:: bash
 
     # Clone the git repository
     $ git clone https://github.com/confluentinc/kafka-streams-examples.git
@@ -63,8 +63,8 @@ Clone the Confluent Docker Images repository:
     # Change into the directory for this tutorial
     $ cd kafka-streams-examples/
 
-    # Switch to the `3.3.0-post` branch
-    $ git checkout 3.3.0-post
+    # Switch to the `|release|-post` branch
+    $ git checkout |release|-post
 
 Now we can launch the Kafka Music demo application including the services it depends on such as Kafka.
 


### PR DESCRIPTION
The docs have been telling people to checkout 'master' for the music example since 4.0, but they should be checking out that version's branch. This was actually correct before 4.0 but let's just replace with |release| everywhere for consistency