### PR TITLE
Use |release| macro for branch name in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ Ready now?  Let's start!
 
 Clone the Confluent Docker Images repository:
 
-  .. sourcecode:: bash
+  .. codewithcars:: bash
 
     # Clone the git repository
     $ git clone https://github.com/confluentinc/kafka-streams-examples.git
@@ -63,8 +63,8 @@ Clone the Confluent Docker Images repository:
     # Change into the directory for this tutorial
     $ cd kafka-streams-examples/
 
-    # Switch to the `master` branch
-    $ git checkout master
+    # Switch to the `|release|-post` branch
+    $ git checkout |release|-post
 
 Now we can launch the Kafka Music demo application including the services it depends on such as Kafka.
 


### PR DESCRIPTION
Same as [266 ](https://github.com/confluentinc/kafka-streams-examples/pull/266/files) but targeted at 4.0.0-post to avoid merge conflicts on pint merge 