### PR TITLE
Fix replication factor in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,8 +64,8 @@ services:
     # See https://docs.docker.com/compose/startup-order/
     command: "bash -c 'echo Waiting for Kafka to be ready... && \
                        cub kafka-ready -b kafka:29092 1 20 && \
-                       kafka-topics --create --topic play-events --if-not-exists --zookeeper zookeeper:32181 --partitions 4 --replication-factor 1 && \
-                       kafka-topics --create --topic song-feed --if-not-exists --zookeeper zookeeper:32181 --partitions 4 --replication-factor 1 && \
+                       kafka-topics --create --topic play-events --if-not-exists --zookeeper zookeeper:32181 --partitions 4 --replication-factor 3 && \
+                       kafka-topics --create --topic song-feed --if-not-exists --zookeeper zookeeper:32181 --partitions 4 --replication-factor 3 && \
                        sleep infinity'"
     environment:
       # The following settings are listed here only to satisfy the image's requirements.


### PR DESCRIPTION
The music demo app has been broken since 5.2 in part because the topics need to be created with a  replication factor of 3.

Note, this only partially fixes the demo -- see [KSTREAMS-2990](https://confluentinc.atlassian.net/browse/KSTREAMS-2990) 