### PR TITLE
Add new Aggregate and Reduce examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Additional examples may be found under [src/test/](src/test/java/io/confluent/ex
 | ----------------------------------- | ------------------------------------------- | ------- | ------- | ----- |
 | WordCount                           | DSL, aggregation, stateful                  | [Java 8+ Example](src/test/java/io/confluent/examples/streams/WordCountLambdaIntegrationTest.java) | | [Scala Example](src/test/scala/io/confluent/examples/streams/WordCountScalaIntegrationTest.scala) |
 | WordCountInteractiveQueries         | Interactive Queries, REST, RPC              | | [Java 7+ Example](src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java) | |
+| Aggregate                           | DSL, `groupBy()`, `aggregate()`             | [Java 8+ Example](src/test/java/io/confluent/examples/streams/AggregateTest.java) | | [Scala Example](src/test/scala/io/confluent/examples/streams/AggregateScalaTest.scala) |
 | CustomStreamTableJoin               | DSL, Processor API, Transformers            | [Java 8+ Example](src/test/java/io/confluent/examples/streams/CustomStreamTableJoinIntegrationTest.java) | | |
 | EventDeduplication                  | DSL, Processor API, Transformers            | [Java 8+ Example](src/test/java/io/confluent/examples/streams/EventDeduplicationLambdaIntegrationTest.java) | | |
 | GlobalKTable                        | DSL, global state                           | | [Java 7+ Example](src/test/java/io/confluent/examples/streams/GlobalKTablesExampleTest.java) | |
@@ -114,6 +115,7 @@ Additional examples may be found under [src/test/](src/test/java/io/confluent/ex
 | PassThrough                         | DSL, `stream()`, `to()`                     | | [Java 7+ Example](src/test/java/io/confluent/examples/streams/PassThroughIntegrationTest.java) | |
 | PoisonPill                          | DSL, `flatMap()`                            | [Java 8+ Example](src/test/java/io/confluent/examples/streams/HandlingCorruptedInputRecordsIntegrationTest.java) | | |
 | ProbabilisticCounting\*\*\*         | DSL, Processor API, custom state stores     | | | [Scala Example](src/test/scala/io/confluent/examples/streams/ProbabilisticCountingScalaIntegrationTest.scala) |
+| Reduce (Concatenate)                | DSL, `groupByKey()`, `reduce()`             | [Java 8+ Example](src/test/java/io/confluent/examples/streams/ReduceTest.java) | | [Scala Example](src/test/scala/io/confluent/examples/streams/ReduceScalaTest.scala) |
 | SessionWindows                      | DSL, windowed aggregation, sessionization   | | [Java 7+ Example](src/test/java/io/confluent/examples/streams/SessionWindowsExampleTest.java) | |
 | StatesStoresDSL                     | DSL, Processor API, Transformers            | [Java 8+ Example](src/test/java/io/confluent/examples/streams/StateStoresInTheDSLIntegrationTest.java) | | |
 | StreamToStreamJoin                  | DSL, `join()` between KStream and KStream   | | [Java 7+ Example](src/test/java/io/confluent/examples/streams/StreamToStreamJoinIntegrationTest.java) | |

--- a/src/test/java/io/confluent/examples/streams/AggregateTest.java
+++ b/src/test/java/io/confluent/examples/streams/AggregateTest.java
@@ -46,6 +46,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * only certain field(s) in the input.
  *
  * Note: This example uses lambda expressions and thus works with Java 8+ only.
+ *
+ * See {@link AggregateScalaTest} for the equivalent Scala example.
  */
 public class AggregateTest {
 

--- a/src/test/java/io/confluent/examples/streams/AggregateTest.java
+++ b/src/test/java/io/confluent/examples/streams/AggregateTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams;
+
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.test.TestUtils;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * How to aggregate messages via `groupBy()` and `aggregate()`.
+ *
+ * This example can be adapted to structured (nested) data formats such as Avro or JSON in case you need to aggregate
+ * only certain field(s) in the input.
+ *
+ * Note: This example uses lambda expressions and thus works with Java 8+ only.
+ */
+public class AggregateTest {
+
+  private static final String inputTopic = "inputTopic";
+  private static final String outputTopic = "outputTopic";
+
+  @Test
+  public void shouldAggregate() {
+    final List<String> inputValues = Arrays.asList(
+      "stream", "all", "the", "things", "hi", "world", "kafka", "streams", "streaming"
+    );
+
+    // We want to compute the sum of the length of words (values) by the first letter (new key) of words.
+    final Map<String, Long> expectedOutput = new HashMap<>();
+    expectedOutput.put("a", 3L);
+    expectedOutput.put("t", 9L);
+    expectedOutput.put("h", 2L);
+    expectedOutput.put("w", 5L);
+    expectedOutput.put("k", 5L);
+    expectedOutput.put("s", 22L);
+
+    // Step 1: Create the topology and its configuration
+    final StreamsBuilder builder = createTopology();
+    final Properties streamsConfiguration = createTopologyConfiguration();
+
+    try (final TopologyTestDriver testDriver = new TopologyTestDriver(builder.build(), streamsConfiguration)) {
+      // Step 2: Write the input
+      IntegrationTestUtils.produceValuesSynchronously(inputTopic, inputValues, testDriver, new StringSerializer());
+
+      // Step 3: Validate the output
+      final Map<String, Long> actualOutput = IntegrationTestUtils.drainTableOutput(
+        outputTopic, testDriver, new StringDeserializer(), new LongDeserializer());
+      assertThat(actualOutput).isEqualTo(expectedOutput);
+    }
+  }
+
+  private StreamsBuilder createTopology() {
+    final StreamsBuilder builder = new StreamsBuilder();
+    final KStream<byte[], String> input = builder.stream(inputTopic, Consumed.with(Serdes.ByteArray(), Serdes.String()));
+    final KTable<String, Long> aggregated = input
+      // We set the new key of a word (value) to the word's first letter.
+      .groupBy(
+        (key, value) -> (value != null && value.length() > 0) ? value.substring(0, 1).toLowerCase() : "",
+        Grouped.with(Serdes.String(), Serdes.String()))
+      // For each first letter (key), we compute the sum of the word lengths.
+      .aggregate(
+        () -> 0L,
+        (aggKey, newValue, aggValue) -> aggValue + newValue.length(),
+        Materialized.with(Serdes.String(), Serdes.Long())
+      );
+    aggregated.toStream().to(outputTopic, Produced.with(Serdes.String(), Serdes.Long()));
+    return builder;
+  }
+
+  private Properties createTopologyConfiguration() {
+    final Properties streamsConfiguration = new Properties();
+    streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "aggregate-test");
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
+    // Use a temporary directory for storing state, which will be automatically removed after the test.
+    streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
+    return streamsConfiguration;
+  }
+
+}

--- a/src/test/java/io/confluent/examples/streams/IntegrationTestUtils.java
+++ b/src/test/java/io/confluent/examples/streams/IntegrationTestUtils.java
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
@@ -169,6 +170,28 @@ public class IntegrationTestUtils {
             .map(record -> new KeyValue<>(null, record))
             .collect(Collectors.toList());
     produceKeyValuesSynchronously(topic, keyedRecords, producerConfig);
+  }
+
+  /**
+   * Like {@link IntegrationTestUtils#produceValuesSynchronously(String, Collection, Properties)}, except for use with
+   * TopologyTestDriver tests, rather than "native" Kafka broker tests.
+   *
+   * @param topic              Kafka topic to write the data records to
+   * @param values             Message values to write to Kafka (keys will have type byte[] and be set to null)
+   * @param topologyTestDriver The {@link TopologyTestDriver} to send the data records to
+   * @param valueSerializer    The {@link Serializer} corresponding to the value type
+   * @param <V>                Value type of the data records
+   */
+  static <K, V> void produceValuesSynchronously(final String topic,
+                                                final List<V> values,
+                                                final TopologyTestDriver topologyTestDriver,
+                                                final Serializer<V> valueSerializer) {
+    final List<KeyValue<byte[], V>> keyedRecords =
+      values
+        .stream()
+        .map(value -> new KeyValue<byte[], V>(null, value))
+        .collect(Collectors.toList());
+    produceKeyValuesSynchronously(topic, keyedRecords, topologyTestDriver, new ByteArraySerializer(), valueSerializer);
   }
 
   public static <K, V> List<KeyValue<K, V>> waitUntilMinKeyValueRecordsReceived(

--- a/src/test/java/io/confluent/examples/streams/ReduceTest.java
+++ b/src/test/java/io/confluent/examples/streams/ReduceTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams;
+
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.test.TestUtils;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * How to aggregate messages via `groupByKey()` and `reduce()` to implement concatenation of data.
+ *
+ * This example can be adapted to structured (nested) data formats such as Avro or JSON in case you need to concatenate
+ * only certain field(s) in the input.
+ *
+ * Note: This example uses lambda expressions and thus works with Java 8+ only.
+ */
+public class ReduceTest {
+
+  private static final String inputTopic = "inputTopic";
+  private static final String outputTopic = "outputTopic";
+
+  @Test
+  public void shouldConcatenateWithReduce() {
+    final List<KeyValue<Integer, String>> inputRecords = Arrays.asList(
+      new KeyValue<>(456, "stream"),
+      new KeyValue<>(123, "hello"),
+      new KeyValue<>(123, "world"),
+      new KeyValue<>(456, "all"),
+      new KeyValue<>(123, "kafka"),
+      new KeyValue<>(456, "the"),
+      new KeyValue<>(456, "things"),
+      new KeyValue<>(123, "streams")
+    );
+
+    // For each record key, we want to concatenate the record values.
+    final Map<Integer, String> expectedOutput = new HashMap<>();
+    expectedOutput.put(456, "stream all the things");
+    expectedOutput.put(123, "hello world kafka streams");
+
+    // Step 1: Create the topology and its configuration
+    final StreamsBuilder builder = createTopology();
+    final Properties streamsConfiguration = createTopologyConfiguration();
+
+    try (final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration)) {
+      // Step 2: Write the input
+      IntegrationTestUtils.produceKeyValuesSynchronously(
+        inputTopic, inputRecords, topologyTestDriver, new IntegerSerializer(), new StringSerializer());
+
+      // Step 3: Validate the output
+      final Map<Integer, String> actualOutput = IntegrationTestUtils.drainTableOutput(
+        outputTopic, topologyTestDriver, new IntegerDeserializer(), new StringDeserializer());
+      assertThat(actualOutput).hasSameSizeAs(expectedOutput);
+      assertThat(actualOutput).containsAllEntriesOf(expectedOutput);
+    }
+  }
+
+  private StreamsBuilder createTopology() {
+    final StreamsBuilder builder = new StreamsBuilder();
+    final KStream<Integer, String> input = builder.stream(inputTopic, Consumed.with(Serdes.Integer(), Serdes.String()));
+    final KTable<Integer, String> concatenated =
+      input
+        // Group the records based on the existing key of records.
+        .groupByKey(Grouped.with(Serdes.Integer(), Serdes.String()))
+        // For each key, concatenate the record values.
+        .reduce((v1, v2) -> v1 + " " + v2);
+    concatenated.toStream().to(outputTopic, Produced.with(Serdes.Integer(), Serdes.String()));
+    return builder;
+  }
+
+  private Properties createTopologyConfiguration() {
+    final Properties streamsConfiguration = new Properties();
+    streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "reduce-test");
+    streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
+    // Use a temporary directory for storing state, which will be automatically removed after the test.
+    streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
+    return streamsConfiguration;
+  }
+
+}

--- a/src/test/java/io/confluent/examples/streams/ReduceTest.java
+++ b/src/test/java/io/confluent/examples/streams/ReduceTest.java
@@ -47,6 +47,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * only certain field(s) in the input.
  *
  * Note: This example uses lambda expressions and thus works with Java 8+ only.
+ *
+ * See {@link ReduceScalaTest} for the equivalent Scala example.
  */
 public class ReduceTest {
 

--- a/src/test/scala/io/confluent/examples/streams/AggregateScalaTest.scala
+++ b/src/test/scala/io/confluent/examples/streams/AggregateScalaTest.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams
+
+import java.util.Properties
+
+import org.apache.kafka.streams.scala.StreamsBuilder
+import org.apache.kafka.streams.scala.kstream.{KStream, KTable}
+import org.apache.kafka.streams.{StreamsConfig, TopologyTestDriver}
+import org.apache.kafka.test.TestUtils
+import org.junit._
+import org.scalatest.junit.AssertionsForJUnit
+
+/**
+  * End-to-end integration test that shows how to aggregate messages via `groupBy()` and `aggregate()`.
+  *
+  * See [[AggregateTest]] for the equivalent Java example.
+  */
+class AggregateScalaTest extends AssertionsForJUnit {
+
+  import org.apache.kafka.streams.scala.ImplicitConversions._
+  import org.apache.kafka.streams.scala.Serdes._
+
+  private val inputTopic = "inputTopic"
+  private val outputTopic = "output-topic"
+
+  @Test
+  def shouldAggregate() {
+    val inputValues: Seq[String] =
+      Seq("stream", "all", "the", "things", "hi", "world", "kafka", "streams", "streaming")
+
+    // We want to compute the sum of the length of words (values) by the first letter (new key) of words.
+    val expectedOutput: Map[String, Long] = Map(
+      "a" -> 3L,
+      "t" -> 9L,
+      "h" -> 2L,
+      "w" -> 5L,
+      "k" -> 5L,
+      "s" -> 22L,
+    )
+
+    // Step 1: Create the topology and its configuration
+    val builder: StreamsBuilder = createTopology()
+    val streamsConfiguration = createTopologyConfiguration()
+
+    val topologyTestDriver: TopologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration)
+    try {
+      // Step 2: Write the input
+      import IntegrationTestScalaUtils._
+      IntegrationTestScalaUtils.produceValuesSynchronously(inputTopic, inputValues, topologyTestDriver)
+
+      // Step 3: Validate the output
+      val actualOutput = IntegrationTestScalaUtils.drainTableOutput[String, Long](outputTopic, topologyTestDriver)
+      assert(actualOutput === expectedOutput)
+    } finally {
+      topologyTestDriver.close()
+    }
+  }
+
+  def createTopology(): StreamsBuilder = {
+    val builder = new StreamsBuilder
+    val input: KStream[Array[Byte], String] = builder.stream[Array[Byte], String](inputTopic)
+    val aggregated: KTable[String, Long] = input
+      // We set the new key of a word (value) to the word's first letter.
+      .groupBy(
+      (key: Array[Byte], value: String) => Option(value) match {
+        case Some(s) if s.nonEmpty => s.head.toString
+        case _ => ""
+      })
+      // For each first letter (key), we compute the sum of the word lengths.
+      .aggregate(0L)((aggKey: String, newValue: String, aggValue: Long) => aggValue + newValue.length)
+    aggregated.toStream.to(outputTopic)
+    builder
+  }
+
+  def createTopologyConfiguration(): Properties = {
+    val p = new Properties()
+    p.put(StreamsConfig.APPLICATION_ID_CONFIG, "aggregate-scala-test")
+    p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy-config")
+    // Use a temporary directory for storing state, which will be automatically removed after the test.
+    p.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory.getAbsolutePath)
+    p
+  }
+
+}

--- a/src/test/scala/io/confluent/examples/streams/IntegrationTestScalaUtils.scala
+++ b/src/test/scala/io/confluent/examples/streams/IntegrationTestScalaUtils.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams
+
+import org.apache.kafka.common.serialization.{Deserializer, Serde, Serializer, Serdes => JSerdes}
+import org.apache.kafka.streams.kstream.{Windowed, WindowedSerdes}
+import org.apache.kafka.streams.{KeyValue, TopologyTestDriver}
+
+/**
+  * Makes the use of [[IntegrationTestUtils]] from Scala more convenient by providing implicit serializers and
+  * deserializers. For example, it saves you from distinguishing between Scala's [[Int]] and Java's [[Integer]] when
+  * reading from or writing to Kafka.
+  */
+object IntegrationTestScalaUtils {
+
+  implicit def StringSerializer: Serializer[String] = JSerdes.String().serializer()
+
+  implicit def LongSerializer: Serializer[Long] = JSerdes.Long().asInstanceOf[Serde[Long]].serializer()
+
+  implicit def JavaLongSerializer: Serializer[java.lang.Long] = JSerdes.Long().serializer()
+
+  implicit def ByteArraySerializer: Serializer[Array[Byte]] = JSerdes.ByteArray().serializer()
+
+  implicit def BytesSerializer: Serializer[org.apache.kafka.common.utils.Bytes] = JSerdes.Bytes().serializer()
+
+  implicit def FloatSerializer: Serializer[Float] = JSerdes.Float().asInstanceOf[Serde[Float]].serializer()
+
+  implicit def JavaFloatSerializer: Serializer[java.lang.Float] = JSerdes.Float().serializer()
+
+  implicit def DoubleSerializer: Serializer[Double] = JSerdes.Double().asInstanceOf[Serde[Double]].serializer()
+
+  implicit def JavaDoubleSerializer: Serializer[java.lang.Double] = JSerdes.Double().serializer()
+
+  implicit def IntegerSerializer: Serializer[Int] = JSerdes.Integer().asInstanceOf[Serde[Int]].serializer()
+
+  implicit def JavaIntegerSerializer: Serializer[java.lang.Integer] = JSerdes.Integer().serializer()
+
+  implicit def timeWindowedSerializer[T]: Serializer[Windowed[T]] =
+    new WindowedSerdes.TimeWindowedSerde[T]().serializer()
+
+  implicit def sessionWindowedSerializer[T]: Serializer[Windowed[T]] =
+    new WindowedSerdes.SessionWindowedSerde[T]().serializer()
+
+  implicit def StringDeserializer: Deserializer[String] = JSerdes.String().deserializer()
+
+  implicit def LongDeserializer: Deserializer[Long] = JSerdes.Long().asInstanceOf[Serde[Long]].deserializer()
+
+  implicit def JavaLongDeserializer: Deserializer[java.lang.Long] = JSerdes.Long().deserializer()
+
+  implicit def ByteArrayDeserializer: Deserializer[Array[Byte]] = JSerdes.ByteArray().deserializer()
+
+  implicit def BytesDeserializer: Deserializer[org.apache.kafka.common.utils.Bytes] = JSerdes.Bytes().deserializer()
+
+  implicit def FloatDeserializer: Deserializer[Float] = JSerdes.Float().asInstanceOf[Serde[Float]].deserializer()
+
+  implicit def JavaFloatDeserializer: Deserializer[java.lang.Float] = JSerdes.Float().deserializer()
+
+  implicit def DoubleDeserializer: Deserializer[Double] = JSerdes.Double().asInstanceOf[Serde[Double]].deserializer()
+
+  implicit def JavaDoubleDeserializer: Deserializer[java.lang.Double] = JSerdes.Double().deserializer()
+
+  implicit def IntegerDeserializer: Deserializer[Int] = JSerdes.Integer().asInstanceOf[Serde[Int]].deserializer()
+
+  implicit def JavaIntegerDeserializer: Deserializer[java.lang.Integer] = JSerdes.Integer().deserializer()
+
+  implicit def timeWindowedDeserializer[T]: Deserializer[Windowed[T]] =
+    new WindowedSerdes.TimeWindowedSerde[T]().deserializer()
+
+  implicit def sessionWindowedDeserializer[T]: Deserializer[Windowed[T]] =
+    new WindowedSerdes.SessionWindowedSerde[T]().deserializer()
+
+  def produceValuesSynchronously[V](topic: String, values: Seq[V], driver: TopologyTestDriver)
+                                   (implicit valueSerializer: Serializer[V]): Unit = {
+    import collection.JavaConverters._
+    IntegrationTestUtils.produceValuesSynchronously(topic, values.asJava, driver, valueSerializer)
+  }
+
+  def produceKeyValuesSynchronously[K, V](topic: String, records: Seq[KeyValue[K, V]], driver: TopologyTestDriver)
+                                         (implicit keySer: Serializer[K], valueSer: Serializer[V]) = {
+    import collection.JavaConverters._
+    IntegrationTestUtils.produceKeyValuesSynchronously(topic, records.asJava, driver, keySer, valueSer)
+  }
+
+  def drainStreamOutput[K, V](topic: String, driver: TopologyTestDriver)
+                             (implicit keyDeser: Deserializer[K], valueDeser: Deserializer[V]): Seq[KeyValue[K, V]] = {
+    import collection.JavaConverters._
+    IntegrationTestUtils.drainStreamOutput(topic, driver, keyDeser, valueDeser).asScala
+  }
+
+  def drainTableOutput[K, V](topic: String, driver: TopologyTestDriver)
+                            (implicit keyDeser: Deserializer[K], valueDeser: Deserializer[V]): Map[K, V] = {
+    import collection.JavaConverters._
+    IntegrationTestUtils.drainTableOutput(topic, driver, keyDeser, valueDeser).asScala.toMap
+  }
+
+}

--- a/src/test/scala/io/confluent/examples/streams/ReduceScalaTest.scala
+++ b/src/test/scala/io/confluent/examples/streams/ReduceScalaTest.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.examples.streams
+
+import java.util.Properties
+
+import org.apache.kafka.streams.scala.StreamsBuilder
+import org.apache.kafka.streams.scala.kstream.{KStream, KTable}
+import org.apache.kafka.streams.{KeyValue, StreamsConfig, TopologyTestDriver}
+import org.apache.kafka.test.TestUtils
+import org.junit._
+import org.scalatest.junit.AssertionsForJUnit
+
+/**
+  * End-to-end integration test that shows how to aggregate messages via `groupByKey()` and `reduce()`.
+  *
+  * This example can be adapted to structured (nested) data formats such as Avro or JSON in case you need to concatenate
+  * only certain field(s) in the input.
+  *
+  * See [[ReduceTest]] for the equivalent Java example.
+  */
+class ReduceScalaTest extends AssertionsForJUnit {
+
+  import org.apache.kafka.streams.scala.ImplicitConversions._
+  import org.apache.kafka.streams.scala.Serdes._
+
+  private val inputTopic = "inputTopic"
+  private val outputTopic = "output-topic"
+
+  @Test
+  def shouldConcatenateWithReduce() {
+    val inputRecords: Seq[KeyValue[Int, String]] = Seq(
+      (456, "stream"),
+      (123, "hello"),
+      (123, "world"),
+      (456, "all"),
+      (123, "kafka"),
+      (456, "the"),
+      (456, "things"),
+      (123, "streams")
+    )
+
+    // For each record key, we want to concatenate the record values.
+    val expectedOutput: Map[Int, String] = Map(
+      456 -> "stream all the things",
+      123 -> "hello world kafka streams"
+    )
+
+    // Step 1: Create the topology and its configuration
+    val builder: StreamsBuilder = createTopology()
+    val streamsConfiguration = createTopologyConfiguration()
+
+    val topologyTestDriver: TopologyTestDriver = new TopologyTestDriver(builder.build(), streamsConfiguration)
+    try {
+      // Step 2: Write the input
+      import IntegrationTestScalaUtils._
+      IntegrationTestScalaUtils.produceKeyValuesSynchronously(inputTopic, inputRecords, topologyTestDriver)
+
+      // Step 3: Validate the output
+      val actualOutput = IntegrationTestScalaUtils.drainTableOutput[Int, String](outputTopic, topologyTestDriver)
+      assert(actualOutput === expectedOutput)
+    } finally {
+      topologyTestDriver.close()
+    }
+  }
+
+  def createTopology(): StreamsBuilder = {
+    val builder = new StreamsBuilder
+    val input: KStream[Int, String] = builder.stream[Int, String](inputTopic)
+    val concatenated: KTable[Int, String] =
+      input
+        // Group the records based on the existing key of records.
+        .groupByKey
+        // For each key, concatenate the record values.
+        .reduce((v1, v2) => v1 + " " + v2)
+    concatenated.toStream.to(outputTopic)
+    builder
+  }
+
+  def createTopologyConfiguration(): Properties = {
+    val p = new Properties()
+    p.put(StreamsConfig.APPLICATION_ID_CONFIG, "reduce-scala-test")
+    p.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config")
+    // Use a temporary directory for storing state, which will be automatically removed after the test.
+    p.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory.getAbsolutePath)
+    p
+  }
+
+}


### PR DESCRIPTION
This is a subset of the original PR at https://github.com/confluentinc/kafka-streams-examples/pull/235 that contains only the new Aggregate + Reduce tests in Java and Scala, plus an updated IntegrationTestUtils (Java) and a new IntegrationTestScalaUtils.