### PR TITLE
IntegrationTestUtils: correctly handle null keys and null values when draining table output

### DIFF
--- a/src/test/java/io/confluent/examples/streams/IntegrationTestUtils.java
+++ b/src/test/java/io/confluent/examples/streams/IntegrationTestUtils.java
@@ -339,10 +339,16 @@ public class IntegrationTestUtils {
     final Map<K, V> results = new LinkedHashMap<>();
     while (true) {
       final ProducerRecord<K, V> record = topologyTestDriver.readOutput(topic, keyDeserializer, valueDeserializer);
-      if (record == null) {
+      // Tables ignore records with null keys.
+      if (record == null || record.key() == null) {
         break;
       } else {
-        results.put(record.key(), record.value());
+        // For tables, a null-valued record represents a "DELETE" or tombstone for the corresponding key.
+        if (record.value() == null) {
+          results.remove(record.key());
+        } else {
+          results.put(record.key(), record.value());
+        }
       }
     }
     return results;


### PR DESCRIPTION
`IntegrationTestUtils#drainTableOutput()` does not remove null-valued entries from the map that it returns, though it should.

The method should return just the "effective table", not the full changelog (= all records in a table’s changelog). Hence null-valued entries should be removed.