### PR TITLE
Remove SNAPSHOT from standalone jar

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
                        cub kafka-ready -b kafka:29092 1 20 && \
                        echo Waiting for Confluent Schema Registry to be ready... && \
                        cub sr-ready schema-registry 8081 20 && \
-                       java -cp /usr/share/java/kafka-streams-examples/kafka-streams-examples-5.3.0-SNAPSHOT-standalone.jar \
+                       java -cp /usr/share/java/kafka-streams-examples/kafka-streams-examples-5.3.0-standalone.jar \
                        io.confluent.examples.streams.interactivequeries.kafkamusic.KafkaMusicExampleDriver \
                        kafka:29092 http://schema-registry:8081'"
     environment:


### PR DESCRIPTION
When the 5.3.0-post branch was cut it removed the -SNAPSHOT from all image version number references in the docker-compose but missed the name of the jar

Will talk to tools about fixing this going forward