### PR TITLE
Set KAFKA_MUSIC_APP_REST_HOST to 0.0.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,7 @@ services:
       STREAMS_BOOTSTRAP_SERVERS: kafka:29092
       STREAMS_SCHEMA_REGISTRY_HOST: schema-registry
       STREAMS_SCHEMA_REGISTRY_PORT: 8081
-      KAFKA_MUSIC_APP_REST_HOST: localhost
+      KAFKA_MUSIC_APP_REST_HOST: 0.0.0.0
       KAFKA_MUSIC_APP_REST_PORT: 7070
     extra_hosts:
       - "moby:127.0.0.1"


### PR DESCRIPTION
The music demo app has been "broken" for kafka-streams-examples images 5.1.0 and later, where the IQ results were not visible outside the container. 

This PR is targeted at 5.2.0-post since 5.1.0-post mistakenly uses the 5.0.0 image -- will fix in a follow up PR