### PR TITLE
Fix empty response from server when running curl on music demo app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,7 +130,7 @@ services:
       STREAMS_BOOTSTRAP_SERVERS: kafka:29092
       STREAMS_SCHEMA_REGISTRY_HOST: schema-registry
       STREAMS_SCHEMA_REGISTRY_PORT: 8081
-      KAFKA_MUSIC_APP_REST_HOST: 0.0.0.0
+      KAFKA_MUSIC_APP_REST_HOST: kafka-music-application
       KAFKA_MUSIC_APP_REST_PORT: 7070
     extra_hosts:
       - "moby:127.0.0.1"


### PR DESCRIPTION
This allows curling the music demo app outside of the running container. 