### PR TITLE
Configure music app REST host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,7 @@ services:
       STREAMS_BOOTSTRAP_SERVERS: kafka:29092
       STREAMS_SCHEMA_REGISTRY_HOST: schema-registry
       STREAMS_SCHEMA_REGISTRY_PORT: 8081
-      KAFKA_MUSIC_APP_REST_HOST: 0.0.0.0
+      KAFKA_MUSIC_APP_REST_HOST: kafka-music-application
       KAFKA_MUSIC_APP_REST_PORT: 7070
     extra_hosts:
       - "moby:127.0.0.1"


### PR DESCRIPTION
Follow up to [282](https://github.com/confluentinc/kafka-streams-examples/pull/282) because pint merge resulted in conflicts for 5.2.0+