### PR TITLE
MINOR: Update timeout

### DIFF
--- a/src/test/java/io/confluent/examples/streams/microservices/util/MicroserviceTestUtils.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/util/MicroserviceTestUtils.java
@@ -114,7 +114,7 @@ public class MicroserviceTestUtils {
         actualValues.add(KeyValue.pair(record.key(), record.value()));
       }
       return actualValues.size() == numberToRead;
-    }, 20000, "Timed out reading orders.");
+    }, 40000, "Timed out reading orders.");
     consumer.close();
     return actualValues;
   }


### PR DESCRIPTION
Although not a great practice, some of the restful integration tests could stand a bump in the timeout. I am doing this in `3.3.0-post` as we've seen the same error in `4.x` and `5.x` branches.