### PR TITLE
Fix Slack integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,4 +11,5 @@ docker_oraclejdk8 {
     // nodeLabel = 'docker-oraclejdk8-compose'
     upstreamProjects = 'confluentinc/common'
     withPush = true
+    slackChannel = 'streams-alerts'
 }


### PR DESCRIPTION
Follow up to #290

Without a slack channel specified, it falls back to an incorrect default channel.