### PR TITLE
Use docker swarm nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,4 +5,5 @@ dockerfile {
     mvnPhase = 'package'  // streams examples integration-test needs host-based networking, won't work in CI as-is
     mvnSkipDeploy = true
     upstreamProjects = 'confluentinc/rest-utils'
+    nodeLabel = 'docker-oraclejdk8-compose-swarm'
 }


### PR DESCRIPTION
We should be using the new docker swarm nodes because the pool is much bigger.