### PR TITLE
ST-2560: Adding support for building debian and rhel images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 ARG STREAMS_VERSION
 ARG ARTIFACT_ID
 
-MAINTAINER partner-support@confluent.io
+LABEL MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,4 +7,6 @@ dockerfile {
     upstreamProjects = 'confluentinc/rest-utils'
     nodeLabel = 'docker-oraclejdk8-compose-swarm'
     cron = ''
+    cpImages = true
+    osTypes = ['deb9', 'rhel8']
 }

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala.version>${kafka.scala.version}.8</scala.version>
         <scalatest.version>3.0.5</scalatest.version>
+        <docker.os_type>deb9</docker.os_type>
+        <!-- Need to explicitly set this otherwise it will be overridden from common-docker pom. -->
+        <docker.file>Dockerfile</docker.file>
+        <docker.tag>${project.version}-${docker.os_type}</docker.tag>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Since this image is built from artifacts and not packages we don't need to create separate docker files for each os type we want to build, which is the pattern we use with the other images that are built from packages. This change will build the same docker file twice but each time using a different docker upstream tag so that it uses a different base image each time. 

I have tested the debian images locally and it worked with cp-demo. Testing of the rhel images with cp-demo is still on going.