### PR TITLE
Bump 5.4.x branch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0-SNAPSHOT
+    image: confluentinc/cp-zookeeper:5.4.x-latest
     hostname: zookeeper
     ports:
       - '32181:32181'
@@ -13,7 +13,7 @@ services:
       - "moby:127.0.0.1"
 
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.4.0-SNAPSHOT
+    image: confluentinc/cp-enterprise-kafka:5.4.x-latest
     hostname: kafka
     ports:
       - '9092:9092'
@@ -38,7 +38,7 @@ services:
       - "moby:127.0.0.1"
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.4.0-SNAPSHOT
+    image: confluentinc/cp-schema-registry:5.4.x-latest
     hostname: schema-registry
     depends_on:
       - zookeeper
@@ -54,7 +54,7 @@ services:
   # This "container" is a workaround to pre-create topics for the Kafka Music application
   # until we have a more elegant way to do that.
   kafka-create-topics:
-    image: confluentinc/cp-kafka:5.4.0-SNAPSHOT
+    image: confluentinc/cp-kafka:5.4.x-latest
     depends_on:
       - kafka
     hostname: kafka-create-topics
@@ -78,7 +78,7 @@ services:
 
   # Continuously generates input data for the Kafka Music application.
   kafka-music-data-generator:
-    image: confluentinc/kafka-streams-examples:5.4.0-SNAPSHOT
+    image: confluentinc/kafka-streams-examples:5.4.x-latest
     hostname: kafka-music-data-generator
     depends_on:
       - kafka
@@ -103,7 +103,7 @@ services:
 
   # Runs the Kafka Music application.
   kafka-music-application:
-    image: confluentinc/kafka-streams-examples:5.4.0-SNAPSHOT
+    image: confluentinc/kafka-streams-examples:5.4.x-latest
     hostname: kafka-music-application
     depends_on:
       - kafka


### PR DESCRIPTION
cp-demo: Bump 5.4.x branch

Issue:
Docker image tag got bumped to in-correct value for docker image tags during 5.4.x branch cut.

Solution
- learn about all the changes required for devx repositories both during branch cut & release version bumps.
- address immediate issue by bumping these to 5.4.x-latest
- update branch cut steps to avoid future issues:
https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/582517464/Major+Minor+Release+Release+Branch+Creation+Feature+Freeze#Major/MinorRelease:ReleaseBranchCreation(FeatureFreeze)-DevXFollowups

Automate via tooling - Added jira to fix tooling:
https://confluentinc.atlassian.net/browse/ST-2650