### PR TITLE
Remove SNAPSHOT suffix from versions in comments

### DIFF
--- a/src/main/java/io/confluent/examples/streams/ApplicationResetExample.java
+++ b/src/main/java/io/confluent/examples/streams/ApplicationResetExample.java
@@ -59,7 +59,7 @@ import java.util.concurrent.CountDownLatch;
  * Once packaged you can then run:
  * <pre>
  * {@code
- * $ java -cp target/kafka-streams-examples-5.4.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.ApplicationResetExample
+ * $ java -cp target/kafka-streams-examples-5.4.0-standalone.jar io.confluent.examples.streams.ApplicationResetExample
  * }
  * </pre>
  * 4) Write some input data to the source topic (e.g. via {@code kafka-console-producer}).
@@ -114,7 +114,7 @@ import java.util.concurrent.CountDownLatch;
  * Thus, restart the application via:
  * <pre>
  * {@code
- * $ java -cp target/kafka-streams-examples-5.4.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.ApplicationResetExample localhost:9092 --reset
+ * $ java -cp target/kafka-streams-examples-5.4.0-standalone.jar io.confluent.examples.streams.ApplicationResetExample localhost:9092 --reset
  * }</pre>
  * 9) If your console consumer (from step 5) is still running, you should see the same output data again.
  * If it was stopped and you restart it, if will print the result "twice".

--- a/src/main/java/io/confluent/examples/streams/GlobalKTablesExample.java
+++ b/src/main/java/io/confluent/examples/streams/GlobalKTablesExample.java
@@ -72,7 +72,7 @@ import java.util.Properties;
  * Once packaged you can then run:
  * <pre>
  * {@code
- * $ java -cp target/kafka-streams-examples-5.4.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.GlobalKTablesExample
+ * $ java -cp target/kafka-streams-examples-5.4.0-standalone.jar io.confluent.examples.streams.GlobalKTablesExample
  * }
  * </pre>
  * 4) Write some input data to the source topics (e.g. via {@link GlobalKTablesExampleDriver}). The
@@ -82,7 +82,7 @@ import java.util.Properties;
  * {@code
  * # Here: Write input data using the example driver. The driver will exit once it has received
  * # all EnrichedOrders
- * $ java -cp target/kafka-streams-examples-5.4.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.GlobalKTablesExampleDriver
+ * $ java -cp target/kafka-streams-examples-5.4.0-standalone.jar io.confluent.examples.streams.GlobalKTablesExampleDriver
  * }
  * </pre>
  * <p>

--- a/src/main/java/io/confluent/examples/streams/GlobalKTablesExampleDriver.java
+++ b/src/main/java/io/confluent/examples/streams/GlobalKTablesExampleDriver.java
@@ -56,7 +56,7 @@ import static io.confluent.examples.streams.GlobalKTablesExample.PRODUCT_TOPIC;
  * Once packaged you can then run:
  * <pre>
  * {@code
- * $ java -cp target/kafka-streams-examples-5.4.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.GlobalKTablesExampleDriver
+ * $ java -cp target/kafka-streams-examples-5.4.0-standalone.jar io.confluent.examples.streams.GlobalKTablesExampleDriver
  * }
  * </pre>
  */

--- a/src/main/java/io/confluent/examples/streams/JsonToAvroExample.java
+++ b/src/main/java/io/confluent/examples/streams/JsonToAvroExample.java
@@ -56,7 +56,7 @@ import org.codehaus.jackson.map.ObjectMapper;
  * Once packaged you can then run:
  * <pre>
  * {@code
- * $ java -cp target/kafka-streams-examples-5.4.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.JsonToAvroExample
+ * $ java -cp target/kafka-streams-examples-5.4.0-standalone.jar io.confluent.examples.streams.JsonToAvroExample
  * }
  * </pre>
  * 4) Write some input data to the source topics (e.g. via {@link JsonToAvroExampleDriver}). The
@@ -67,7 +67,7 @@ import org.codehaus.jackson.map.ObjectMapper;
  * {@code
  * # Here: Write input data using the example driver.  Once the driver has stopped generating data,
  * # you can terminate it via Ctrl-C.
- * $ java -cp target/kafka-streams-examples-5.4.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.JsonToAvroExampleDriver
+ * $ java -cp target/kafka-streams-examples-5.4.0-standalone.jar io.confluent.examples.streams.JsonToAvroExampleDriver
  * }
  * </pre>
  */

--- a/src/main/java/io/confluent/examples/streams/JsonToAvroExampleDriver.java
+++ b/src/main/java/io/confluent/examples/streams/JsonToAvroExampleDriver.java
@@ -48,7 +48,7 @@ import org.codehaus.jackson.map.ObjectMapper;
  * Once packaged you can then run:
  * <pre>
  * {@code
- * java -cp target/kafka-streams-examples-5.4.0-SNAPSHOT-standalone.jar io.confluent.examples.streams.JsonToAvroExampleDriver
+ * java -cp target/kafka-streams-examples-5.4.0-standalone.jar io.confluent.examples.streams.JsonToAvroExampleDriver
  * }
  * </pre>
  *


### PR DESCRIPTION
The removed SNAPSHOT suffixes were not automatically removed by
Jenkins.

For an example of the SNAPSHOT suffixes removed by Jenkins
see
https://github.com/confluentinc/kafka-streams-examples/commit/fa1a5e1a159a7777912b8e0ae10dcf871a06d183