### PR TITLE
MINOR: Change Avro dependency required for schema registry updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     -->
     <properties>
         <algebird.version>0.13.4</algebird.version>
-        <avro.version>1.8.2</avro.version>
+        <avro.version>1.9.1</avro.version>
         <chill.version>0.9.2</chill.version>
         <docker.skip-build>false</docker.skip-build>
         <docker.skip-test>false</docker.skip-test>
@@ -156,6 +156,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
         <!--

--- a/src/main/java/io/confluent/examples/streams/JsonToAvroExample.java
+++ b/src/main/java/io/confluent/examples/streams/JsonToAvroExample.java
@@ -15,11 +15,11 @@
  */
 package io.confluent.examples.streams;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.examples.streams.avro.WikiFeed;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
-import java.io.IOException;
-import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
@@ -27,8 +27,9 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.IOException;
+import java.util.Properties;
 
 /**
  * A simple example demonstrating how to convert records in JSON format in a given topic to records

--- a/src/main/java/io/confluent/examples/streams/JsonToAvroExampleDriver.java
+++ b/src/main/java/io/confluent/examples/streams/JsonToAvroExampleDriver.java
@@ -15,17 +15,11 @@
  */
 package io.confluent.examples.streams;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.examples.streams.avro.WikiFeed;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 import io.confluent.kafka.streams.serdes.avro.SpecificAvroDeserializer;
-import java.io.IOException;
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -35,7 +29,10 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.*;
 
 /**
  * This is a sample driver for the {@link JsonToAvroExample} and

--- a/src/main/java/io/confluent/examples/streams/JsonToAvroExampleDriver.java
+++ b/src/main/java/io/confluent/examples/streams/JsonToAvroExampleDriver.java
@@ -20,6 +20,12 @@ import io.confluent.examples.streams.avro.WikiFeed;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 import io.confluent.kafka.streams.serdes.avro.SpecificAvroDeserializer;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -31,8 +37,6 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 import java.io.IOException;
-import java.time.Duration;
-import java.util.*;
 
 /**
  * This is a sample driver for the {@link JsonToAvroExample} and

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExample.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExample.java
@@ -471,11 +471,16 @@ public class KafkaMusicExample {
   static class TopFiveSongs implements Iterable<SongPlayCount> {
     private final Map<Long, SongPlayCount> currentSongs = new HashMap<>();
     private final TreeSet<SongPlayCount> topFive = new TreeSet<>((o1, o2) -> {
-      final int result = o2.getPlays().compareTo(o1.getPlays());
+      final Long o1Plays = o1.getPlays();
+      final Long o2Plays = o2.getPlays();
+
+      final int result = o2Plays.compareTo(o1Plays);
       if (result != 0) {
         return result;
       }
-      return o1.getSongId().compareTo(o2.getSongId());
+      final Long o1SongId = o1.getSongId();
+      final Long o2SongId = o2.getSongId();
+      return o1SongId.compareTo(o2SongId);
     });
 
     @Override

--- a/src/main/java/io/confluent/examples/streams/microservices/OrderDetailsService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/OrderDetailsService.java
@@ -171,7 +171,8 @@ public class OrderDetailsService implements Service {
   }
 
   private boolean isValid(final Order order) {
-    if (order.getCustomerId() == null) {
+    final Long customerId = order.getCustomerId();
+    if (customerId == null) {
       return false;
     }
     if (order.getQuantity() < 0) {


### PR DESCRIPTION
Schema registry added pluggable schemas in master, `Avro` dependency needed to get upgraded to 1.9.1.  This PR is needed to fix the kafka-streams-examples master build failures.