### PR TITLE
Docker image names were not updated in 5.4.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.4.x-latest
+    image: confluentinc/cp-zookeeper:5.4.0
     hostname: zookeeper
     ports:
       - '32181:32181'
@@ -13,7 +13,7 @@ services:
       - "moby:127.0.0.1"
 
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.4.x-latest
+    image: confluentinc/cp-enterprise-kafka:5.4.0
     hostname: kafka
     ports:
       - '9092:9092'
@@ -38,7 +38,7 @@ services:
       - "moby:127.0.0.1"
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.4.x-latest
+    image: confluentinc/cp-schema-registry:5.4.0
     hostname: schema-registry
     depends_on:
       - zookeeper
@@ -54,7 +54,7 @@ services:
   # This "container" is a workaround to pre-create topics for the Kafka Music application
   # until we have a more elegant way to do that.
   kafka-create-topics:
-    image: confluentinc/cp-kafka:5.4.x-latest
+    image: confluentinc/cp-kafka:5.4.0
     depends_on:
       - kafka
     hostname: kafka-create-topics
@@ -78,7 +78,7 @@ services:
 
   # Continuously generates input data for the Kafka Music application.
   kafka-music-data-generator:
-    image: confluentinc/kafka-streams-examples:5.4.x-latest
+    image: confluentinc/kafka-streams-examples:5.4.0
     hostname: kafka-music-data-generator
     depends_on:
       - kafka
@@ -103,7 +103,7 @@ services:
 
   # Runs the Kafka Music application.
   kafka-music-application:
-    image: confluentinc/kafka-streams-examples:5.4.x-latest
+    image: confluentinc/kafka-streams-examples:5.4.0
     hostname: kafka-music-application
     depends_on:
       - kafka


### PR DESCRIPTION
Submitted a tools ticket so they can investigate why this is broken before the 5.5.0 and 5.4.1 release/branch cut (I hope).
