### PR TITLE
Output the aggregate result to TiDB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.19</version>
+        </dependency>
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-streams-avro-serde</artifactId>
             <version>${confluent.version}</version>

--- a/src/main/java/io/confluent/examples/streams/TiDBOutputProcessor.java
+++ b/src/main/java/io/confluent/examples/streams/TiDBOutputProcessor.java
@@ -1,0 +1,66 @@
+package io.confluent.examples.streams;
+
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.log4j.Logger;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class TiDBOutputProcessor implements Processor<String, Long> {
+
+    private static final Logger LOG = Logger.getLogger(TiDBOutputProcessor.class);
+
+    private static final String JDBC_DRIVER = "com.mysql.jdbc.Driver";
+    private static final String DB_URL = "jdbc:mysql://127.0.0.1:4000/test";
+
+    //  Database credentials
+    private static final String USER = "root";
+    private static final String PASS = "";
+
+    private static final String QUERY_TEMPLATE = "INSERT INTO wordcount (word, wordcount) VALUES ('%s', %d)";
+
+    private Connection dbConn;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void init(final ProcessorContext context) {
+        // keep the processor context locally because we need it in punctuate() and commit()
+        // TODO: (liquanpei) We would like to schedule a periodic execution to do batch execution
+        try {
+            Class.forName(JDBC_DRIVER);
+            dbConn = DriverManager.getConnection(DB_URL, USER, PASS);
+        } catch (final Exception e) {
+            LOG.error(e);
+        }
+    }
+
+    @Override
+    public void process(final String key, final Long value) {
+        try {
+            // TODD: (liquanpei) We need to batch in insert. There are a couple ways:
+            // 1. Use cache in Kafka Streams.
+            // 2. Use punctuate. Need to verify the semantics.
+            // 3. https://issues.apache.org/jira/browse/KAFKA-6989
+            final Statement statement = dbConn.createStatement();
+            final String query = String.format(QUERY_TEMPLATE, key, value);
+            statement.executeUpdate(query);
+        } catch (final SQLException e) {
+            // To avoid data loss, we need to do infinite retry or crash the application.
+            LOG.error(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        // close any resources managed by this processor
+        // Note: Do not close any StateStores as these are managed by the library
+        try {
+            dbConn.close();
+        } catch (final SQLException e) {
+            LOG.error(e);
+        }
+    }
+}

--- a/src/main/java/io/confluent/examples/streams/WordCountLambdaExample.java
+++ b/src/main/java/io/confluent/examples/streams/WordCountLambdaExample.java
@@ -205,6 +205,10 @@ public class WordCountLambdaExample {
 
     // Write the `KTable<String, Long>` to the output topic.
     wordCounts.toStream().to(outputTopic, Produced.with(Serdes.String(), Serdes.Long()));
+
+    wordCounts.toStream().process(()-> {
+      return new TiDBOutputProcessor();
+    });
   }
 
 }


### PR DESCRIPTION
This is a POC to result to TiDB. 

Here are the steps to run the example: 
1. Follow the instructions in tiup.io to deploy a TiDB cluster. 
2. Connect to TiDB 
`$mysql --host 127.0.0.1 --port 4000 -u root`
3. Create a table under the test database:
`mysql>USE test;`
`mysql>CREATE TABLE wordcount (word VARCHAR(255) NOT NULL, wordcount BIGINT, PRIMARY KEY (word));`
4. Download Kafka, unzip it and in the Kafka directory, start Zookeeper and Kafka
`$bin/zookeeper-server-start.sh config/zookeeper.properties`
`$bin/kafka-server-start.sh config/server.properties`
5. in the Kafka directory, create topics:
`$bin/kafka-topics.sh--create --topic streams-plaintext-input --zookeeper localhost:2181 --partitions 1 --replication-factor 1`
`$bin/kafka-topics --create --topic streams-wordcount-output --zookeeper localhost:2181 --partitions 1 --replication-factor 1`
6. In the kafka-streams-examples directory, build and package the application
`$ mvn -DskipTests=true clean package`
7. In the kafka-streams-examples directory, run the application
`$java -cp target/kafka-streams-examples-5.4.1-standalone.jar \
  io.confluent.examples.streams.WordCountLambdaExample`
8. In the Kafka directory, use the console producer to produce to the input topic
`$bin/kafka-topics.sh --create --topic streams-plaintext-input \
 --zookeeper localhost:2181 --partitions 1 --replication-factor 1`
9. Inspect the result
`mysql> SELECT * from wordcount;`