### PR TITLE
DOCS-2174 Formatting improvements Kafka Streams Example docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,26 +1,26 @@
 .. _docker-tutorial_kafka-streams-examples:
 
-Kafka Streams Demo Application
-------------------------------
+|ak| Streams Demo Application
+-----------------------------
 
-In this tutorial we will run Confluent's
+In this tutorial you will run Confluent's
 :cp-examples:`Kafka Music demo application|src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExample.java`
-for the Kafka Streams API.
+for the |ak-tm| Streams API.
 If you are looking for a similar demo application written with KSQL queries, check out the separate page on the `KSQL music demo walk-thru <https://www.confluent.io/blog/building-streaming-application-ksql/>`__
 
-The Kafka Music application demonstrates how to build a simple music charts application that continuously computes,
+The |ak| Music application demonstrates how to build a simple music charts application that continuously computes,
 in real-time, the latest charts such as Top 5 songs per music genre.  It exposes its latest processing results -- the
-latest charts -- via Kafka's :ref:`Interactive Queries <streams_developer-guide_interactive-queries>` feature and a REST
+latest charts -- via the |ak| :ref:`Interactive Queries <streams_developer-guide_interactive-queries>` feature and a REST
 API.  The application's input data is in Avro format and comes from two sources: a stream of play events (think: "song
 X was played") and a stream of song metadata ("song X was written by artist Y");  see
 :ref:`inspecting the input data <docker-tutorial_kafka-streams-examples_inspect-input-data>` in the
 :ref:`Appendix <docker-tutorial_kafka-streams-examples_appendix>` for how the input data looks like.
 
-More specifically, we will run the following services:
+More specifically, you will run the following services:
 
 - Confluent's
   :cp-examples:`Kafka Music demo application|src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExample.java`
-- a single-node Kafka cluster with a single-node ZooKeeper ensemble
+- a single-node |ak| cluster with a single-node ZooKeeper ensemble
 - :ref:`Confluent Schema Registry <schemaregistry_intro>`
 
 
@@ -34,10 +34,10 @@ This tutorial uses `Docker Compose <https://docs.docker.com/compose/>`__.
 * The Confluent Docker images require Docker version 1.11 or greater.
 
 
-Running the Kafka Music demo application
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Running the |ak| Music demo application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to see an appetizer of what we will do in this section, take a look at the following screencast:
+If you want to see an appetizer of the steps in this section, take a look at the following screencast:
 
 .. raw:: html
 
@@ -54,40 +54,47 @@ If you want to see an appetizer of what we will do in this section, take a look 
 
 Ready now?  Let's start!
 
-Clone the Confluent Docker Images repository:
+#. Clone the Confluent Docker Images repository:
 
-  .. codewithvars:: bash
+   ::
 
-    # Clone the git repository
-    $ git clone https://github.com/confluentinc/kafka-streams-examples.git
+      git clone https://github.com/confluentinc/kafka-streams-examples.git
 
-    # Change into the directory for this tutorial
-    $ cd kafka-streams-examples/
+#. Change into the directory for this tutorial.
 
-    # Switch to the `|release|-post` branch
-    $ git checkout |release|-post
+   ::
 
-Now we can launch the Kafka Music demo application including the services it depends on such as Kafka.
+      cd kafka-streams-examples/
 
-  .. sourcecode:: bash
+#. Switch to the `|release|-post` branch
 
-    $ docker-compose up -d
+   ::
+     
+      git checkout |release|-post
+
+Now, launch the |ak| Music demo application including the services it depends on such as |ak|.
+
+::
+  
+   docker-compose up -d
 
 After a few seconds the application and the services are up and running.  One of the started containers is continuously
 generating input data for the application by writing into its input topics.  This allows us to look at live, real-time
-data when playing around with the Kafka Music application.
+data when playing around with the |ak| Music application.
 
-Now we can use our web browser or a CLI tool such as ``curl`` to interactively query the latest processing results of
-the Kafka Music application by accessing its REST API.
+Now you can use your web browser or a CLI tool such as ``curl`` to interactively query the latest processing results of
+the |ak| Music application by accessing its REST API.
 
-**REST API example 1: list all running application instances of the Kafka Music application:**
+**REST API example 1: list all running application instances of the |ak| Music application:**
 
-.. sourcecode:: bash
+::
+  
+  curl -sXGET http://localhost:7070/kafka-music/instances
 
-    $ curl -sXGET http://localhost:7070/kafka-music/instances
+You should see output similar to following, though here the output is pretty-printed so that it is easier to read:
 
-    # You should see output similar to following, though here
-    # the output is pretty-printed so that it's easier to read:
+::
+  
     [
       {
         "host": "localhost",
@@ -103,12 +110,13 @@ the Kafka Music application by accessing its REST API.
 
 **REST API example 2: get the latest Top 5 songs across all music genres:**
 
-.. sourcecode:: bash
+::
 
-    $ curl -sXGET http://localhost:7070/kafka-music/charts/top-five
+  curl -sXGET http://localhost:7070/kafka-music/charts/top-five
 
-    # You should see output similar to following, though here
-    # the output is pretty-printed so that it's easier to read:
+You should see output similar to following, though here the output is pretty-printed so that it's easier to read:
+
+::
     [
       {
         "artist": "Jello Biafra And The Guantanamo School Of Medicine",
@@ -134,28 +142,28 @@ for details.
 
 Once you're done playing around you can stop all the services and containers with:
 
-.. sourcecode:: bash
-
-    $ docker-compose down
+::
+  
+  docker-compose down
 
 We hope you enjoyed this tutorial!
 
 
-Running further Confluent demo applications for the Kafka Streams API
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Running further Confluent demo applications for the |ak| Streams API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The container named ``kafka-music-application``, which runs the Kafka Music demo application, actually contains all of
+The container named ``kafka-music-application``, which runs the |ak| Music demo application, actually contains all of
 Confluent's `Kafka Streams demo applications <https://github.com/confluentinc/kafka-streams-examples>`__.  The demo applications are
 packaged in the fat jar at ``/usr/share/java/kafka-streams-examples/kafka-streams-examples-|release|-standalone.jar`` inside this container.
 This means you can easily run any of these applications from inside the container via a command similar to:
 
-.. codewithvars:: bash
+Example: Launch the WordCount demo application (inside the `kafka-music-application` container):
 
-    # Example: Launch the WordCount demo application (inside the `kafka-music-application` container)
-    $ docker-compose exec kafka-music-application \
-            java -cp /usr/share/java/kafka-streams-examples/kafka-streams-examples-|release|-standalone.jar \
-            io.confluent.examples.streams.WordCountLambdaExample \
-            kafka:29092
+::
+  $ docker-compose exec kafka-music-application \
+          java -cp /usr/share/java/kafka-streams-examples/kafka-streams-examples-|release|-standalone.jar \
+          io.confluent.examples.streams.WordCountLambdaExample \
+          kafka:29092
 
 Of course you can also modify the tutorial's ``docker-compose.yml`` for repeatable deployments.
 
@@ -176,7 +184,7 @@ Available endpoints **from within the containers** as well as **on your host mac
 | ZooKeeper ensemble        | ``zookeeper.connect``   | ``zookeeper:32181``             | ``localhost:32181``            |
 +---------------------------+-------------------------+---------------------------------+--------------------------------+
 
-The ZooKeeper endpoint is not required by Kafka Streams applications, but you need it to e.g.
+The ZooKeeper endpoint is not required by |ak| Streams applications, but you need it to e.g.
 :ref:`manually create new Kafka topics <docker-tutorial_kafka-streams-examples_topics-create>` or to
 :ref:`list available Kafka topics <docker-tutorial_kafka-streams-examples_topics-list>`.
 
@@ -189,14 +197,16 @@ Appendix
 
 .. _docker-tutorial_kafka-streams-examples_inspect-input-data:
 
-Inspecting the input topics of the Kafka Music application
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Inspecting the input topics of the |ak| Music application
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Inspect the "play-events" input topic, which contains messages in Avro format:
 
-.. sourcecode:: bash
 
-    # Use the kafka-avro-console-consumer to read the "play-events" topic
+Use the kafka-avro-console-consumer to read the "play-events" topic:
+
+::
+  
     $ docker-compose exec schema-registry \
         kafka-avro-console-consumer \
             --bootstrap-server kafka:29092 \
@@ -212,19 +222,21 @@ Inspect the "play-events" input topic, which contains messages in Avro format:
 
 Inspect the "song-feed" input topic, which contains messages in Avro format:
 
-.. sourcecode:: bash
-
+::
     # Use the kafka-avro-console-consumer to read the "song-feed" topic
     $ docker-compose exec schema-registry \
         kafka-avro-console-consumer \
             --bootstrap-server kafka:29092 \
             --topic song-feed --from-beginning
 
-    # You should see output similar to:
-    {"id":1,"album":"Fresh Fruit For Rotting Vegetables","artist":"Dead Kennedys","name":"Chemical Warfare","genre":"Punk"}
-    {"id":2,"album":"We Are the League","artist":"Anti-Nowhere League","name":"Animal","genre":"Punk"}
-    {"id":3,"album":"Live In A Dive","artist":"Subhumans","name":"All Gone Dead","genre":"Punk"}
-    {"id":4,"album":"PSI","artist":"Wheres The Pope?","name":"Fear Of God","genre":"Punk"}
+You should see output similar to:
+
+::
+  
+  {"id":1,"album":"Fresh Fruit For Rotting Vegetables","artist":"Dead Kennedys","name":"Chemical Warfare","genre":"Punk"}
+  {"id":2,"album":"We Are the League","artist":"Anti-Nowhere League","name":"Animal","genre":"Punk"}
+  {"id":3,"album":"Live In A Dive","artist":"Subhumans","name":"All Gone Dead","genre":"Punk"}
+  {"id":4,"album":"PSI","artist":"Wheres The Pope?","name":"Fear Of God","genre":"Punk"}
 
 
 .. _docker-tutorial_kafka-streams-examples_topics-create:
@@ -234,14 +246,18 @@ Creating new topics
 
 You can create topics manually with the ``kafka-topics`` CLI tool, which is available on the ``kafka`` container.
 
-.. sourcecode:: bash
+Create a new topic named "my-new-topic", using the `kafka` container
 
-   # Create a new topic named "my-new-topic", using the `kafka` container
-   $ docker-compose exec kafka kafka-topics \
-       --zookeeper zookeeper:32181 \
-       --create --topic my-new-topic --partitions 2 --replication-factor 1
+::
+  
+   docker-compose exec kafka kafka-topics \
+    --zookeeper zookeeper:32181 \
+    --create --topic my-new-topic --partitions 2 --replication-factor 1
 
-  # You should see a line similar to:
+You should see a line similar to:
+
+::
+
   Created topic "my-new-topic".
 
 
@@ -252,9 +268,11 @@ Listing available topics
 
 You can list all available topics with the ``kafka-topics`` CLI tool, which is available on the ``kafka`` container.
 
-.. sourcecode:: bash
+Run the following command to list available topics, using the ``kafka`` container
 
-   # List available topics, using the `kafka` container
+
+::
+  
    $ docker-compose exec kafka kafka-topics \
        --zookeeper zookeeper:32181 \
        --list

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,9 +66,9 @@ Ready now?  Let's start!
 
       cd kafka-streams-examples/
 
-#. Switch to the `|release|-post` branch
+#. Switch to the ``|release|-post`` branch
 
-   ::
+   .. codewithvars:: bash
      
       git checkout |release|-post
 
@@ -117,6 +117,7 @@ You should see output similar to following, though here the output is pretty-pri
 You should see output similar to following, though here the output is pretty-printed so that it's easier to read:
 
 ::
+  
     [
       {
         "artist": "Jello Biafra And The Guantanamo School Of Medicine",
@@ -159,11 +160,12 @@ This means you can easily run any of these applications from inside the containe
 
 Example: Launch the WordCount demo application (inside the `kafka-music-application` container):
 
-::
-  $ docker-compose exec kafka-music-application \
-          java -cp /usr/share/java/kafka-streams-examples/kafka-streams-examples-|release|-standalone.jar \
-          io.confluent.examples.streams.WordCountLambdaExample \
-          kafka:29092
+.. codewithvars:: bash
+  
+   docker-compose exec kafka-music-application \
+        java -cp /usr/share/java/kafka-streams-examples/kafka-streams-examples-|release|-standalone.jar \
+        io.confluent.examples.streams.WordCountLambdaExample \
+        kafka:29092
 
 Of course you can also modify the tutorial's ``docker-compose.yml`` for repeatable deployments.
 
@@ -205,7 +207,7 @@ Inspect the "play-events" input topic, which contains messages in Avro format:
 
 Use the kafka-avro-console-consumer to read the "play-events" topic:
 
-::
+.. codewithvars:: bash
   
     $ docker-compose exec schema-registry \
         kafka-avro-console-consumer \
@@ -222,7 +224,8 @@ Use the kafka-avro-console-consumer to read the "play-events" topic:
 
 Inspect the "song-feed" input topic, which contains messages in Avro format:
 
-::
+.. codewithvars:: bash
+  
     # Use the kafka-avro-console-consumer to read the "song-feed" topic
     $ docker-compose exec schema-registry \
         kafka-avro-console-consumer \

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. _docker-tutorial_kafka-streams-examples:
+codewithvars.. _docker-tutorial_kafka-streams-examples:
 
 |ak| Streams Demo Application
 -----------------------------
@@ -66,9 +66,9 @@ Ready now?  Let's start!
 
       cd kafka-streams-examples/
 
-#. Switch to the ``|release|-post`` branch
+#. Switch to the |release|-post branch
 
-   .. litwithvars:: bash
+   .. codewithvars:: bash
      
       git checkout |release|-post
 
@@ -160,7 +160,7 @@ This means you can easily run any of these applications from inside the containe
 
 Example: Launch the WordCount demo application (inside the `kafka-music-application` container):
 
-.. litwithvars:: bash
+.. codewithvars:: bash
   
    docker-compose exec kafka-music-application \
         java -cp /usr/share/java/kafka-streams-examples/kafka-streams-examples-|release|-standalone.jar \

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,7 +68,7 @@ Ready now?  Let's start!
 
 #. Switch to the ``|release|-post`` branch
 
-   .. codewithvars:: bash
+   .. litwithvars:: bash
      
       git checkout |release|-post
 
@@ -160,7 +160,7 @@ This means you can easily run any of these applications from inside the containe
 
 Example: Launch the WordCount demo application (inside the `kafka-music-application` container):
 
-.. codewithvars:: bash
+.. litwithvars:: bash
   
    docker-compose exec kafka-music-application \
         java -cp /usr/share/java/kafka-streams-examples/kafka-streams-examples-|release|-standalone.jar \


### PR DESCRIPTION

#### Description

https://confluentinc.atlassian.net/browse/DOCS-2174

- Updated formatting on the ksql Streams examples doc to make it easier to copy-paste examples, and to follow the steps

- The original feedback on the associated Docs ticket was that the example didn't run, but I ran through it on 5.5.0 and it runs fine. I responded to the customer on [this Google email](https://groups.google.com/a/confluent.io/d/msg/docs/p136BvlYoKU/7YxRKu2hAgAJ).

- I didn't know how to test a build of this, so I don't know if my changes will render properly in HTML when built. @JimGalasyn maybe you can show me how to do this?

#### Target Branch:

- 5.3.0-post

Signed-off-by: Victoria Bialas <vicky@confluent.io>