### PR TITLE
Alert slack streams on-call channel on failures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,4 +11,5 @@ docker_oraclejdk8 {
     // nodeLabel = 'docker-oraclejdk8-compose'
     upstreamProjects = 'confluentinc/common'
     withPush = true
+    slackChannel = 'streams-oncall'
 }


### PR DESCRIPTION
Failures here are sent to #tools-notifcations, they should be sent to the streams slack channel.