### PR TITLE
HOTFIX: fix spotbug error

### DIFF
--- a/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
+++ b/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
@@ -97,7 +97,7 @@ import org.apache.kafka.streams.{KafkaStreams, StreamsConfig}
   * 6) Once you're done with your experiments, you can stop this example via `Ctrl-C`.  If needed,
   * also stop the Kafka broker (`Ctrl-C`), and only then stop the ZooKeeper instance (`Ctrl-C`).
   */
-object MapFunctionScalaExample extends App {
+class MapFunctionScalaExample extends App {
 
   import org.apache.kafka.streams.scala.Serdes._
   import org.apache.kafka.streams.scala.ImplicitConversions._

--- a/src/main/scala/io/confluent/examples/streams/WordCountScalaExample.scala
+++ b/src/main/scala/io/confluent/examples/streams/WordCountScalaExample.scala
@@ -89,7 +89,7 @@ import org.apache.kafka.streams.{KafkaStreams, StreamsConfig}
   * 6) Once you're done with your experiments, you can stop this example via `Ctrl-C`. If needed,
   * also stop the Kafka broker (`Ctrl-C`), and only then stop the ZooKeeper instance (`Ctrl-C`).
   **/
-object WordCountScalaExample extends App {
+class WordCountScalaExample extends App {
 
   import org.apache.kafka.streams.scala.Serdes._
   import org.apache.kafka.streams.scala.ImplicitConversions._


### PR DESCRIPTION
I hope this fixed the spotbug issue:
```
19:33:52  [INFO] Total bugs: 8
[2020-06-02T02:33:52.207Z] [ERROR] Write to static field io.confluent.examples.streams.MapFunctionScalaExample$.config from instance method io.confluent.examples.streams.MapFunctionScalaExample$.delayedEndpoint$io$confluent$examples$streams$MapFunctionScalaExample$1() [io.confluent.examples.streams.MapFunctionScalaExample$] At MapFunctionScalaExample.scala:[line 105] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[2020-06-02T02:33:52.207Z] [ERROR] Write to static field io.confluent.examples.streams.MapFunctionScalaExample$.scala$App$$_args from instance method io.confluent.examples.streams.MapFunctionScalaExample$.scala$App$$_args_$eq(String[]) [io.confluent.examples.streams.MapFunctionScalaExample$] At MapFunctionScalaExample.scala:[line 100] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[2020-06-02T02:33:52.207Z] [ERROR] Write to static field io.confluent.examples.streams.MapFunctionScalaExample$.executionStart from instance method io.confluent.examples.streams.MapFunctionScalaExample$.scala$App$_setter_$executionStart_$eq(long) [io.confluent.examples.streams.MapFunctionScalaExample$] At MapFunctionScalaExample.scala:[line 100] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[2020-06-02T02:33:52.207Z] [ERROR] Write to static field io.confluent.examples.streams.MapFunctionScalaExample$.scala$App$$initCode from instance method io.confluent.examples.streams.MapFunctionScalaExample$.scala$App$_setter_$scala$App$$initCode_$eq(ListBuffer) [io.confluent.examples.streams.MapFunctionScalaExample$] At MapFunctionScalaExample.scala:[line 100] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[2020-06-02T02:33:52.207Z] [ERROR] Write to static field io.confluent.examples.streams.WordCountScalaExample$.config from instance method io.confluent.examples.streams.WordCountScalaExample$.delayedEndpoint$io$confluent$examples$streams$WordCountScalaExample$1() [io.confluent.examples.streams.WordCountScalaExample$] At WordCountScalaExample.scala:[line 97] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[2020-06-02T02:33:52.207Z] [ERROR] Write to static field io.confluent.examples.streams.WordCountScalaExample$.scala$App$$_args from instance method io.confluent.examples.streams.WordCountScalaExample$.scala$App$$_args_$eq(String[]) [io.confluent.examples.streams.WordCountScalaExample$] At WordCountScalaExample.scala:[line 92] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[2020-06-02T02:33:52.208Z] [ERROR] Write to static field io.confluent.examples.streams.WordCountScalaExample$.executionStart from instance method io.confluent.examples.streams.WordCountScalaExample$.scala$App$_setter_$executionStart_$eq(long) [io.confluent.examples.streams.WordCountScalaExample$] At WordCountScalaExample.scala:[line 92] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
[2020-06-02T02:33:52.208Z] [ERROR] Write to static field io.confluent.examples.streams.WordCountScalaExample$.scala$App$$initCode from instance method io.confluent.examples.streams.WordCountScalaExample$.scala$App$_setter_$scala$App$$initCode_$eq(ListBuffer) [io.confluent.examples.streams.WordCountScalaExample$] At WordCountScalaExample.scala:[line 92] ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD
```
