### PR TITLE
HOTFIX: revert #340 and disable spotbugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,6 +470,14 @@
             </plugin>
 
             <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <executions>

--- a/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
+++ b/src/main/scala/io/confluent/examples/streams/MapFunctionScalaExample.scala
@@ -97,7 +97,7 @@ import org.apache.kafka.streams.{KafkaStreams, StreamsConfig}
   * 6) Once you're done with your experiments, you can stop this example via `Ctrl-C`.  If needed,
   * also stop the Kafka broker (`Ctrl-C`), and only then stop the ZooKeeper instance (`Ctrl-C`).
   */
-class MapFunctionScalaExample extends App {
+object MapFunctionScalaExample extends App {
 
   import org.apache.kafka.streams.scala.Serdes._
   import org.apache.kafka.streams.scala.ImplicitConversions._

--- a/src/main/scala/io/confluent/examples/streams/WordCountScalaExample.scala
+++ b/src/main/scala/io/confluent/examples/streams/WordCountScalaExample.scala
@@ -89,7 +89,7 @@ import org.apache.kafka.streams.{KafkaStreams, StreamsConfig}
   * 6) Once you're done with your experiments, you can stop this example via `Ctrl-C`. If needed,
   * also stop the Kafka broker (`Ctrl-C`), and only then stop the ZooKeeper instance (`Ctrl-C`).
   **/
-class WordCountScalaExample extends App {
+object WordCountScalaExample extends App {
 
   import org.apache.kafka.streams.scala.Serdes._
   import org.apache.kafka.streams.scala.ImplicitConversions._


### PR DESCRIPTION
Since the upgrade to 2.13, spotbugs is choking on Scala's generated
bytecode. See #340 for the errors. 

The prior fix #340 unintentionally broke the examples by changing
the applications from `object` to `class`, which makes them no longer
runnable. I.e., this change converted the main method to a non-static
method, so there wouldn't be any way to actually run the examples
on the console.

Since this repo doesn't contain any production code (just examples),
we can just disable spotbugs. We still have compiler warnings as
errors and checkstyle.