### PR TITLE
SEC-1034: log4j migration to confluent repackaged version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
+        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+        </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>


### PR DESCRIPTION
@sdanduConf pointed out that the demo is broken because of missing class definitions for `log4j`. The cause was that `log4j` is explicitly blacklisted in `common`. Thiis PR fixes the broken dependencies.