### PR TITLE
SEC-1307: Backport "log4j replacement with confluent repackaged version"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
+        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+        </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>


### PR DESCRIPTION
This pull request cherry-picks a commit from `master` to add explicit `io.confluent:confluent-log4j` dependency, because we blacklist the (vulnerable) tranistive dependency `log4j:log4j` of `org.slf4j:slf4j-log4j12` explicitly in `common`. `io.confluent:confluent-log4j` is a drop-in replacement of `log4j:log4j` with a fix for the vulnerability.