### PR TITLE
MINOR: Add org.junit.jupiter:junit-jupiter-api as Test Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Similar fix to https://github.com/confluentinc/common-docker/pull/111

Include the missing test dependencies to fix the build issue:

```
[2020-09-27T19:46:15.731Z] [ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.005 s <<< FAILURE! - in io.confluent.examples.streams.SpecificAvroIntegrationTest
[2020-09-27T19:46:15.731Z] [ERROR] io.confluent.examples.streams.SpecificAvroIntegrationTest  Time elapsed: 0.004 s  <<< ERROR!
12:46:15  java.lang.NoClassDefFoundError: org/junit/jupiter/api/Assertions
12:46:15  	at io.confluent.examples.streams.SpecificAvroIntegrationTest.startKafkaCluster(SpecificAvroIntegrationTest.java:62)
12:46:15  Caused by: java.lang.ClassNotFoundException: org.junit.jupiter.api.Assertions
12:46:15  	at io.confluent.examples.streams.SpecificAvroIntegrationTest.startKafkaCluster(SpecificAvroIntegrationTest.java:62)
12:46:15  
```