### PR TITLE
ff-4099: bump version of curator test to get rid of javassist.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
-            <version>2.9.0</version>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Curator test brings in Javassist with CVE. This is blocking customers. 

https://confluentinc.atlassian.net/browse/FF-4099?rapidView=323&selectedIssue=FF-1892
https://confluentinc.atlassian.net/wiki/spaces/~913794610/pages/1809418291/Javassist+and+Guava+Workpage
