### PR TITLE
MINOR: use isolated state.dir for each KafkaStreams client

### DIFF
--- a/src/main/java/io/confluent/examples/streams/microservices/OrdersService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/OrdersService.java
@@ -325,6 +325,7 @@ public class OrdersService implements Service {
     jettyServer = startJetty(port, this);
     port = jettyServer.getURI().getPort(); // update port, in case port was zero
     producer = startProducer(bootstrapServers, ORDERS, defaultConfig);
+    defaultConfig.put(StreamsConfig.STATE_DIR_CONFIG, stateDir);
     streams = startKStreams(bootstrapServers, defaultConfig);
     log.info("Started Service " + getClass().getSimpleName());
     log.info("Order Service listening at:" + jettyServer.getURI().toString());

--- a/src/main/java/io/confluent/examples/streams/microservices/OrdersService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/OrdersService.java
@@ -358,10 +358,10 @@ public class OrdersService implements Service {
   }
 
   private Properties config(final String bootstrapServers, final Properties defaultConfig) {
-    final String statDir = defaultConfig.getProperty(StreamsConfig.STATE_DIR_CONFIG);
+    final String stateDir = defaultConfig.getProperty(StreamsConfig.STATE_DIR_CONFIG);
     final Properties props = baseStreamsConfig(
             bootstrapServers,
-            statDir != null ? statDir : "/tmp/kafka-streams",
+            stateDir != null ? stateDir : "/tmp/kafka-streams",
             SERVICE_APP_ID,
             defaultConfig);
     props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, host + ":" + port);

--- a/src/main/java/io/confluent/examples/streams/microservices/OrdersService.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/OrdersService.java
@@ -358,9 +358,10 @@ public class OrdersService implements Service {
   }
 
   private Properties config(final String bootstrapServers, final Properties defaultConfig) {
+    final String statDir = defaultConfig.getProperty(StreamsConfig.STATE_DIR_CONFIG);
     final Properties props = baseStreamsConfig(
             bootstrapServers,
-            "/tmp/kafka-streams",
+            statDir != null ? statDir : "/tmp/kafka-streams",
             SERVICE_APP_ID,
             defaultConfig);
     props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, host + ":" + port);

--- a/src/test/java/io/confluent/examples/streams/microservices/OrdersServiceTest.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/OrdersServiceTest.java
@@ -22,6 +22,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
+import java.io.File;
 import java.net.HttpURLConnection;
 import java.time.Duration;
 import java.util.Collections;
@@ -177,10 +178,18 @@ public class OrdersServiceTest extends MicroserviceTestUtils {
 
     //Given two rest servers on different ports
     rest = new OrdersService("localhost");
-    rest.start(CLUSTER.bootstrapServers(), TestUtils.tempDirectory().getPath(), new Properties());
+    rest.start(
+            CLUSTER.bootstrapServers(),
+            TestUtils.tempDirectory().getPath() + File.separator + "instance-1",
+            new Properties()
+    );
     final Paths paths1 = new Paths("localhost", rest.port());
     rest2 = new OrdersService("localhost");
-    rest2.start(CLUSTER.bootstrapServers(), TestUtils.tempDirectory().getPath(), new Properties());
+    rest2.start(
+            CLUSTER.bootstrapServers(),
+            TestUtils.tempDirectory().getPath() + File.separator + "instance-2",
+            new Properties()
+    );
     final Paths paths2 = new Paths("localhost", rest2.port());
 
     //And one order


### PR DESCRIPTION
With https://github.com/apache/kafka/pull/9978 we start to lock the state directory and disallow to share it across multiple `KafkaStreams` instances.