### PR TITLE
MINOR: remove dropped methods

### DIFF
--- a/src/main/java/io/confluent/examples/streams/interactivequeries/MetadataService.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/MetadataService.java
@@ -17,12 +17,15 @@ package io.confluent.examples.streams.interactivequeries;
 
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.state.StreamsMetadata;
 
 import javax.ws.rs.NotFoundException;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.apache.kafka.common.utils.Utils.mkSet;
 
 /**
  * Looks up StreamsMetadata from KafkaStreams and converts the results
@@ -70,14 +73,14 @@ public class MetadataService {
                                                          final Serializer<K> serializer) {
     // Get metadata for the instances of this Kafka Streams application hosting the store and
     // potentially the value for key
-    final StreamsMetadata metadata = streams.metadataForKey(store, key, serializer);
+    final KeyQueryMetadata metadata = streams.queryMetadataForKey(store, key, serializer);
     if (metadata == null) {
       throw new NotFoundException();
     }
 
-    return new HostStoreInfo(metadata.host(),
-                             metadata.port(),
-                             metadata.stateStoreNames());
+    return new HostStoreInfo(metadata.activeHost().host(),
+                             metadata.activeHost().port(),
+                             mkSet(store));
   }
 
   private List<HostStoreInfo> mapInstancesToHostStoreInfo(

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesRestService.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesRestService.java
@@ -48,6 +48,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import static org.apache.kafka.streams.StoreQueryParameters.fromNameAndType;
+
 /**
  *  A simple REST proxy that runs embedded in the {@link WordCountInteractiveQueriesExample}. This is used to
  *  demonstrate how a developer can use the Interactive Queries APIs exposed by Kafka Streams to
@@ -89,7 +91,8 @@ public class WordCountInteractiveQueriesRestService {
     }
 
     // Lookup the KeyValueStore with the provided storeName
-    final ReadOnlyKeyValueStore<String, Long> store = streams.store(storeName, QueryableStoreTypes.keyValueStore());
+    final ReadOnlyKeyValueStore<String, Long> store =
+            streams.store(fromNameAndType(storeName, QueryableStoreTypes.keyValueStore()));
     if (store == null) {
       throw new NotFoundException();
     }
@@ -158,8 +161,8 @@ public class WordCountInteractiveQueriesRestService {
                                           @PathParam("to") final Long to) {
 
     // Lookup the WindowStore with the provided storeName
-    final ReadOnlyWindowStore<String, Long> store = streams.store(storeName,
-                                                                  QueryableStoreTypes.windowStore());
+    final ReadOnlyWindowStore<String, Long> store =
+            streams.store(fromNameAndType(storeName, QueryableStoreTypes.windowStore()));
     if (store == null) {
       throw new NotFoundException();
     }
@@ -227,7 +230,8 @@ public class WordCountInteractiveQueriesRestService {
                                                        KeyValueIterator<String, Long>> rangeFunction) {
 
     // Get the KeyValue Store
-    final ReadOnlyKeyValueStore<String, Long> store = streams.store(storeName, QueryableStoreTypes.keyValueStore());
+    final ReadOnlyKeyValueStore<String, Long> store =
+            streams.store(fromNameAndType(storeName, QueryableStoreTypes.keyValueStore()));
     final List<KeyValueBean> results = new ArrayList<>();
     // Apply the function, i.e., query the store
     final KeyValueIterator<String, Long> range = rangeFunction.apply(store);

--- a/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/MusicPlaysRestService.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/kafkamusic/MusicPlaysRestService.java
@@ -47,6 +47,8 @@ import javax.ws.rs.core.MediaType;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.kafka.streams.StoreQueryParameters.fromNameAndType;
+
 /**
  *  A simple REST proxy that runs embedded in the {@link KafkaMusicExample}. This is used to
  *  demonstrate how a developer can use the Interactive Queries APIs exposed by Kafka Streams to
@@ -130,7 +132,7 @@ public class MusicPlaysRestService {
                                                final String storeName) {
 
     final ReadOnlyKeyValueStore<String, KafkaMusicExample.TopFiveSongs> topFiveStore =
-        streams.store(storeName, QueryableStoreTypes.keyValueStore());
+        streams.store(fromNameAndType(storeName, QueryableStoreTypes.keyValueStore()));
     // Get the value from the store
     final KafkaMusicExample.TopFiveSongs value = topFiveStore.get(key);
     if (value == null) {
@@ -157,8 +159,8 @@ public class MusicPlaysRestService {
                                           songPlayCount.getPlays()));
       } else {
         // look in the local store
-        final ReadOnlyKeyValueStore<Long, Song> songStore = streams.store(KafkaMusicExample.ALL_SONGS,
-                                                                          QueryableStoreTypes.keyValueStore());
+        final ReadOnlyKeyValueStore<Long, Song> songStore =
+                streams.store(fromNameAndType(KafkaMusicExample.ALL_SONGS, QueryableStoreTypes.keyValueStore()));
         final Song song = songStore.get(songPlayCount.getSongId());
         results.add(new SongPlayCountBean(song.getArtist(), song.getAlbum(), song.getName(),
                                           songPlayCount.getPlays()));
@@ -171,8 +173,8 @@ public class MusicPlaysRestService {
   @Path("/song/{id}")
   @Produces(MediaType.APPLICATION_JSON)
   public SongBean song(@PathParam("id") final Long songId) {
-    final ReadOnlyKeyValueStore<Long, Song> songStore = streams.store(KafkaMusicExample.ALL_SONGS,
-                                                                      QueryableStoreTypes.keyValueStore());
+    final ReadOnlyKeyValueStore<Long, Song> songStore =
+            streams.store(fromNameAndType(KafkaMusicExample.ALL_SONGS, QueryableStoreTypes.keyValueStore()));
     final Song song = songStore.get(songId);
     if (song == null) {
       throw new NotFoundException(String.format("Song with id [%d] was not found", songId));

--- a/src/main/java/io/confluent/examples/streams/microservices/util/MicroserviceUtils.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/util/MicroserviceUtils.java
@@ -103,7 +103,7 @@ public class MicroserviceUtils {
     }
 
     @Override
-    public void close(String storeName, Options options) {
+    public void close(final String storeName, final Options options) {
 
     }
   }

--- a/src/main/java/io/confluent/examples/streams/microservices/util/MicroserviceUtils.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/util/MicroserviceUtils.java
@@ -101,6 +101,11 @@ public class MicroserviceUtils {
       // Set number of compaction threads (but not flush threads).
       options.setIncreaseParallelism(compactionParallelism);
     }
+
+    @Override
+    public void close(String storeName, Options options) {
+
+    }
   }
 
   //Streams doesn't provide an Enum serdes so just create one here.

--- a/src/test/java/io/confluent/examples/streams/IntegrationTestUtils.java
+++ b/src/test/java/io/confluent/examples/streams/IntegrationTestUtils.java
@@ -25,10 +25,7 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
-import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
@@ -242,33 +239,6 @@ public class IntegrationTestUtils {
             " but received only " + accumData.size() +
             " records before timeout " + waitTime + " ms");
       Thread.sleep(Math.min(waitTime, 100L));
-    }
-  }
-
-  /**
-   * Waits until the named store is queryable and, once it is, returns a reference to the store.
-   * <p>
-   * Caveat: This is a point in time view and it may change due to partition reassignment.
-   * That is, the returned store may still not be queryable in case a rebalancing is happening or
-   * happened around the same time.  This caveat is acceptable for testing purposes when only a
-   * single `KafkaStreams` instance of the application is running.
-   *
-   * @param streams            the `KafkaStreams` instance to which the store belongs
-   * @param storeName          the name of the store
-   * @param queryableStoreType the type of the (queryable) store
-   * @param <T>                the type of the (queryable) store
-   * @return the same store, which is now ready for querying (but see caveat above)
-   */
-  public static <T> T waitUntilStoreIsQueryable(final String storeName,
-                                                final QueryableStoreType<T> queryableStoreType,
-                                                final KafkaStreams streams) throws InterruptedException {
-    while (true) {
-      try {
-        return streams.store(storeName, queryableStoreType);
-      } catch (final InvalidStateStoreException ignored) {
-        // store not yet ready for querying
-        Thread.sleep(50);
-      }
     }
   }
 

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/kafkamusic/KafkaMusicExampleTest.java
@@ -64,6 +64,7 @@ import java.util.stream.IntStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static junit.framework.TestCase.fail;
+import static org.apache.kafka.streams.StoreQueryParameters.fromNameAndType;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -239,7 +240,7 @@ public class KafkaMusicExampleTest {
       TestUtils.waitForCondition(() -> {
         final ReadOnlyKeyValueStore<Long, Song> songsStore;
         try {
-          songsStore = streams.store(KafkaMusicExample.ALL_SONGS, QueryableStoreTypes.keyValueStore());
+          songsStore = streams.store(fromNameAndType(KafkaMusicExample.ALL_SONGS, QueryableStoreTypes.keyValueStore()));
           return songsStore.all().hasNext();
         } catch (final Exception e) {
           e.printStackTrace();


### PR DESCRIPTION
Several long-deprecated methods are being dropped from Kafka Streams.
Unfortunately, we were still using several of them.