### PR TITLE
MINOR: bump timeout to stabilize test

### DIFF
--- a/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
@@ -138,7 +138,7 @@ public class WordCountInteractiveQueriesExampleTest {
     });
     kafkaStreams.start();
 
-    assertTrue("streams failed to start within timeout", startupLatch.await(30, TimeUnit.SECONDS));
+    assertTrue("streams failed to start within timeout", startupLatch.await(60, TimeUnit.SECONDS));
 
     bindHostAndStartRestProxy(port, host);
   


### PR DESCRIPTION
Running this test locally, if failed reliably with the 30sec timeout and the issue went await with the 60sec timeout.