### PR TITLE
Migrate off of deprecated SchemaRegistry zk config, use bootstrap servers config instead

### DIFF
--- a/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
+++ b/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
@@ -169,17 +169,6 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
   }
 
   /**
-   * This cluster's ZK connection string aka `zookeeper.connect` in `hostnameOrIp:port` format.
-   * Example: `127.0.0.1:2181`.
-   * <p>
-   * You can use this to e.g. tell Kafka consumers (old consumer API) how to connect to this
-   * cluster.
-   */
-  public String zookeeperConnect() {
-    return zookeeper.connectString();
-  }
-
-  /**
    * The "schema.registry.url" setting of the schema registry instance.
    */
   public String schemaRegistryUrl() {

--- a/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
+++ b/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
@@ -43,7 +43,7 @@ import java.util.Set;
 public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
 
   private static final Logger log = LoggerFactory.getLogger(EmbeddedSingleNodeKafkaCluster.class);
-  private static final int DEFAULT_BROKER_PORT = 0; // 0 results in a random port being selected
+  private static final int DEFAULT_BROKER_PORT = 1234; // pick a random port
   private static final String KAFKA_SCHEMAS_TOPIC = "_schemas";
   private static final String AVRO_COMPATIBILITY_TYPE = CompatibilityLevel.NONE.name;
 

--- a/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
+++ b/src/test/java/io/confluent/examples/streams/kafka/EmbeddedSingleNodeKafkaCluster.java
@@ -96,8 +96,9 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     schemaRegistryProps.put(SchemaRegistryConfig.KAFKASTORE_TIMEOUT_CONFIG, KAFKASTORE_OPERATION_TIMEOUT_MS);
     schemaRegistryProps.put(SchemaRegistryConfig.DEBUG_CONFIG, KAFKASTORE_DEBUG);
     schemaRegistryProps.put(SchemaRegistryConfig.KAFKASTORE_INIT_TIMEOUT_CONFIG, KAFKASTORE_INIT_TIMEOUT);
+    schemaRegistryProps.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, effectiveBrokerConfig.getProperty(KafkaConfig.ListenersProp()));
 
-    schemaRegistry = new RestApp(0, zookeeperConnect(), KAFKA_SCHEMAS_TOPIC, AVRO_COMPATIBILITY_TYPE, schemaRegistryProps);
+    schemaRegistry = new RestApp(0, null, KAFKA_SCHEMAS_TOPIC, AVRO_COMPATIBILITY_TYPE, schemaRegistryProps);
     schemaRegistry.start();
     running = true;
   }


### PR DESCRIPTION
In [#1936](https://github.com/confluentinc/schema-registry/commit/06738ad7ce75cb1105a65d8356938751d7d68273#diff-685a652ce1af196ad342417568034ad869e6f3875a886566652064935fc64bdeL645-L655), SchemaRegistry started to enforce that `KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG` be set, rather than allowing the app to use either that or `KAFKASTORE_CONNECTION_URL_CONFIG` which turned out to. be a deprecated zookeeper-specific config that we apparently still used.
