### PR TITLE
fix: update lambda integration test with new null serde changes

### DIFF
--- a/src/test/java/io/confluent/examples/streams/FanoutLambdaIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/FanoutLambdaIntegrationTest.java
@@ -72,6 +72,7 @@ public class FanoutLambdaIntegrationTest {
     streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "fanout-lambda-integration-test");
     streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy config");
     streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+    streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.ByteArray().getClass().getName());
 
     final String inputTopicA = "A";
     final String outputTopicB = "B";


### PR DESCRIPTION
We recently [changed the default serde to be null](https://github.com/apache/kafka/pull/10813) and therefore need to update this test to make sure it properly sets a key serde