### PR TITLE
Correct internal API to use string instead of boolean

### DIFF
--- a/src/main/scala/io/confluent/examples/streams/algebird/CMSStoreChangeLogger.scala
+++ b/src/main/scala/io/confluent/examples/streams/algebird/CMSStoreChangeLogger.scala
@@ -33,7 +33,7 @@ class CMSStoreChangeLogger[K, V](val storeName: String,
                                  val partition: Int,
                                  val serialization: StateSerdes[K, V]) {
 
-  private val topic = ProcessorStateManager.storeChangelogTopic(context.applicationId, storeName, false)
+  private val topic = ProcessorStateManager.storeChangelogTopic(context.applicationId, storeName, context.taskId().namedTopology())
   private val collector = context.asInstanceOf[RecordCollector.Supplier].recordCollector
 
   def this(storeName: String, context: StateStoreContext, serialization: StateSerdes[K, V]) = {

--- a/src/test/java/io/confluent/examples/streams/microservices/InventoryServiceTest.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/InventoryServiceTest.java
@@ -92,10 +92,17 @@ public class InventoryServiceTest extends MicroserviceTestUtils {
 
   private List<KeyValue<Product, Long>> readInventoryStateStore(final int numberOfRecordsToWaitFor)
       throws InterruptedException {
+    // named topologies are experimental, using `null` for now
     return IntegrationTestUtils
-        .waitUntilMinKeyValueRecordsReceived(inventoryConsumerProperties(CLUSTER),
-            ProcessorStateManager.storeChangelogTopic(InventoryService.SERVICE_APP_ID,
-                InventoryService.RESERVED_STOCK_STORE_NAME), numberOfRecordsToWaitFor);
+        .waitUntilMinKeyValueRecordsReceived(
+            inventoryConsumerProperties(CLUSTER),
+            ProcessorStateManager.storeChangelogTopic(
+                InventoryService.SERVICE_APP_ID,
+                InventoryService.RESERVED_STOCK_STORE_NAME,
+                null
+            ),
+            numberOfRecordsToWaitFor
+        );
   }
 
   private static Properties inventoryConsumerProperties(final EmbeddedSingleNodeKafkaCluster cluster) {


### PR DESCRIPTION
saw a bunch of failures here: https://confluentinc.atlassian.net/browse/KSQL-6263
recent logs indicate that there was a parameter mismatch:
`[2021-08-09T13:45:35.897Z] [ERROR] /home/jenkins/workspace/nc_kafka-streams-examples_master/src/main/scala/io/confluent/examples/streams/algebird/CMSStoreChangeLogger.scala:36: error: type mismatch;
[2021-08-09T13:45:35.897Z] [ERROR]  found   : Boolean(false)
[2021-08-09T13:45:35.897Z] [ERROR]  required: String
[2021-08-09T13:45:35.897Z] [ERROR]   private val topic = ProcessorStateManager.storeChangelogTopic(context.applicationId, storeName, false)`

the current internal api takes `public static String storeChangelogTopic(final String applicationId, final String storeName, final String namedTopology)`