### PR TITLE
MINOR: fix compile error

### DIFF
--- a/src/main/scala/io/confluent/examples/streams/algebird/CMSStoreChangeLogger.scala
+++ b/src/main/scala/io/confluent/examples/streams/algebird/CMSStoreChangeLogger.scala
@@ -33,7 +33,7 @@ class CMSStoreChangeLogger[K, V](val storeName: String,
                                  val partition: Int,
                                  val serialization: StateSerdes[K, V]) {
 
-  private val topic = ProcessorStateManager.storeChangelogTopic(context.applicationId, storeName, context.taskId().namedTopology())
+  private val topic = ProcessorStateManager.storeChangelogTopic(context.applicationId, storeName, context.taskId().topologyName())
   private val collector = context.asInstanceOf[RecordCollector.Supplier].recordCollector
 
   def this(storeName: String, context: StateStoreContext, serialization: StateSerdes[K, V]) = {


### PR DESCRIPTION
The changed API is public, but it's not release yet, thus there is no upstream deprecation necessary, but the KIP was changed.