### PR TITLE
Update Jenkinsfile Nodelabel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ dockerfile {
     mvnPhase = 'package'  // streams examples integration-test needs host-based networking, won't work in CI as-is
     mvnSkipDeploy = true
     upstreamProjects = 'confluentinc/rest-utils'
-    nodeLabel = 'docker-oraclejdk8-compose-swarm'
+    nodeLabel = 'docker-debian-jdk8-compose'
     cron = ''
     cpImages = true
     osTypes = ['deb9', 'ubi8']


### PR DESCRIPTION
Update Jenkinsfile nodelabel to use new build image. Moving from Debian Jessie (EOL) to Debian Buster.

Context on new image: https://github.com/confluentinc/confluent-docker-build-images/pull/165/files

This will be pint merged up to master.