### PR TITLE
update examples to use retries of 1 for idempotent producer

### DIFF
--- a/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesDriver.java
+++ b/src/main/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesDriver.java
@@ -62,7 +62,7 @@ public class WordCountInteractiveQueriesDriver {
     final Properties producerConfig = new Properties();
     producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
+    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 1);
     producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
 

--- a/src/main/java/io/confluent/examples/streams/microservices/AddInventory.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/AddInventory.java
@@ -33,7 +33,7 @@ public class AddInventory {
         producerConfig.putAll(defaultConfig);
         producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-        producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
+        producerConfig.put(ProducerConfig.RETRIES_CONFIG, 1);
         producerConfig.put(ProducerConfig.CLIENT_ID_CONFIG, "inventory-generator");
         MonitoringInterceptorUtils.maybeConfigureInterceptorsProducer(producerConfig);
 

--- a/src/main/java/io/confluent/examples/streams/microservices/PostOrdersAndPayments.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/PostOrdersAndPayments.java
@@ -51,7 +51,7 @@ public class PostOrdersAndPayments {
         producerConfig.putAll(defaultConfig);
         producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-        producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
+        producerConfig.put(ProducerConfig.RETRIES_CONFIG, 1);
         producerConfig.put(ProducerConfig.CLIENT_ID_CONFIG, "payment-generator");
         MonitoringInterceptorUtils.maybeConfigureInterceptorsProducer(producerConfig);
 

--- a/src/main/java/io/confluent/examples/streams/microservices/util/ProduceCustomers.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/util/ProduceCustomers.java
@@ -61,7 +61,7 @@ public class ProduceCustomers {
         props.putAll(defaultConfig);
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ProducerConfig.ACKS_CONFIG, "all");
-        props.put(ProducerConfig.RETRIES_CONFIG, 0);
+        props.put(ProducerConfig.RETRIES_CONFIG, 1);
         MonitoringInterceptorUtils.maybeConfigureInterceptorsProducer(props);
 
         try (final KafkaProducer<Long, Customer> producer = new KafkaProducer<>(props, new LongSerializer(), mySerializer)) {

--- a/src/main/java/io/confluent/examples/streams/microservices/util/ProduceOrders.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/util/ProduceOrders.java
@@ -63,7 +63,7 @@ public class ProduceOrders {
         props.putAll(defaultConfig);
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ProducerConfig.ACKS_CONFIG, "all");
-        props.put(ProducerConfig.RETRIES_CONFIG, 0);
+        props.put(ProducerConfig.RETRIES_CONFIG, 1);
         MonitoringInterceptorUtils.maybeConfigureInterceptorsProducer(props);
 
         try (final KafkaProducer<String, Order> producer = new KafkaProducer<>(props, new StringSerializer(), mySerializer)) {

--- a/src/main/java/io/confluent/examples/streams/microservices/util/ProducePayments.java
+++ b/src/main/java/io/confluent/examples/streams/microservices/util/ProducePayments.java
@@ -61,7 +61,7 @@ public class ProducePayments {
         props.putAll(defaultConfig);
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ProducerConfig.ACKS_CONFIG, "all");
-        props.put(ProducerConfig.RETRIES_CONFIG, 0);
+        props.put(ProducerConfig.RETRIES_CONFIG, 1);
         MonitoringInterceptorUtils.maybeConfigureInterceptorsProducer(props);
 
         try (final KafkaProducer<String, Payment> producer = new KafkaProducer<>(props, new StringSerializer(), mySerializer)) {

--- a/src/test/java/io/confluent/examples/streams/ApplicationResetIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/ApplicationResetIntegrationTest.java
@@ -100,7 +100,7 @@ public class ApplicationResetIntegrationTest {
       final Properties producerConfig = new Properties();
       producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
       producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-      producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
+      producerConfig.put(ProducerConfig.RETRIES_CONFIG, 1);
       producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
       producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
       IntegrationTestUtils.produceValuesSynchronously(inputTopic, inputValues, producerConfig);

--- a/src/test/java/io/confluent/examples/streams/CustomStreamTableJoinIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/CustomStreamTableJoinIntegrationTest.java
@@ -345,7 +345,7 @@ public class CustomStreamTableJoinIntegrationTest {
     final Properties producerConfigStream = new Properties();
     producerConfigStream.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
     producerConfigStream.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfigStream.put(ProducerConfig.RETRIES_CONFIG, 0);
+    producerConfigStream.put(ProducerConfig.RETRIES_CONFIG, 1);
     producerConfigStream.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     producerConfigStream.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, DoubleSerializer.class);
     IntegrationTestUtils.produceKeyValuesWithTimestampsSynchronously(
@@ -357,7 +357,7 @@ public class CustomStreamTableJoinIntegrationTest {
     final Properties producerConfigTable = new Properties();
     producerConfigTable.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
     producerConfigTable.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfigTable.put(ProducerConfig.RETRIES_CONFIG, 0);
+    producerConfigTable.put(ProducerConfig.RETRIES_CONFIG, 1);
     producerConfigTable.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     producerConfigTable.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
     IntegrationTestUtils.produceKeyValuesWithTimestampsSynchronously(

--- a/src/test/java/io/confluent/examples/streams/SpecificAvroIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/SpecificAvroIntegrationTest.java
@@ -113,7 +113,7 @@ public class SpecificAvroIntegrationTest {
     final Properties producerConfig = new Properties();
     producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
     producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
+    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 1);
     producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
     producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class);
     producerConfig.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, CLUSTER.schemaRegistryUrl());

--- a/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
+++ b/src/test/java/io/confluent/examples/streams/interactivequeries/WordCountInteractiveQueriesExampleTest.java
@@ -102,7 +102,7 @@ public class WordCountInteractiveQueriesExampleTest {
     final Properties producerConfig = new Properties();
     producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
     producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
+    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 1);
     producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     IntegrationTestUtils.produceValuesSynchronously(

--- a/src/test/java/io/confluent/examples/streams/microservices/util/MicroserviceTestUtils.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/util/MicroserviceTestUtils.java
@@ -71,7 +71,7 @@ public class MicroserviceTestUtils {
     final Properties producerConfig = new Properties();
     producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
     producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
+    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 1);
     return producerConfig;
   }
 

--- a/src/test/scala/io/confluent/examples/streams/GenericAvroScalaIntegrationTest.scala
+++ b/src/test/scala/io/confluent/examples/streams/GenericAvroScalaIntegrationTest.scala
@@ -99,7 +99,7 @@ class GenericAvroScalaIntegrationTest extends AssertionsForJUnit {
       val p = new Properties()
       p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers())
       p.put(ProducerConfig.ACKS_CONFIG, "all")
-      p.put(ProducerConfig.RETRIES_CONFIG, "0")
+      p.put(ProducerConfig.RETRIES_CONFIG, "1")
       p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer])
       p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[KafkaAvroSerializer])
       p.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, cluster.schemaRegistryUrl)

--- a/src/test/scala/io/confluent/examples/streams/SpecificAvroScalaIntegrationTest.scala
+++ b/src/test/scala/io/confluent/examples/streams/SpecificAvroScalaIntegrationTest.scala
@@ -92,7 +92,7 @@ class SpecificAvroScalaIntegrationTest extends AssertionsForJUnit {
       val p = new Properties()
       p.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers())
       p.put(ProducerConfig.ACKS_CONFIG, "all")
-      p.put(ProducerConfig.RETRIES_CONFIG, "0")
+      p.put(ProducerConfig.RETRIES_CONFIG, "1")
       p.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer])
       p.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[KafkaAvroSerializer])
       p.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, cluster.schemaRegistryUrl)


### PR DESCRIPTION
see failures here: https://jenkins.confluent.io/job/confluentinc/job/kafka-streams-examples/job/7.0.x/604/testReport/

testing done: ran test