### PR TITLE
Docker compose init failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
       - '8081:8081'
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'kafka:29092'
+      SCHEMA_REGISTRY_LISTENERS: "http://0.0.0.0:8081"
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:32181
     extra_hosts:
       - "moby:127.0.0.1"
@@ -65,8 +67,9 @@ services:
     # See https://docs.docker.com/compose/startup-order/
     command: "bash -c 'echo Waiting for Kafka to be ready... && \
                        cub kafka-ready -b kafka:29092 1 20 && \
-                       kafka-topics --create --topic play-events --if-not-exists --zookeeper zookeeper:32181 --partitions 4 --replication-factor 1 && \
-                       kafka-topics --create --topic song-feed --if-not-exists --zookeeper zookeeper:32181 --partitions 4 --replication-factor 1 && \
+                       kafka-topics --create --topic play-events --if-not-exists --bootstrap-server kafka:29092 --partitions 4 --replication-factor 1 && \
+                       kafka-topics --create --topic play-events-per-session --if-not-exists --bootstrap-server kafka:29092 --partitions 4 --replication-factor 1 && \
+                       kafka-topics --create --topic song-feed --if-not-exists --bootstrap-server kafka:29092 --partitions 4 --replication-factor 1 && \
                        sleep infinity'"
     environment:
       # The following settings are listed here only to satisfy the image's requirements.


### PR DESCRIPTION
fixed:
- docker-compose was using old kafka-topics parameters (not creating the topic)
- schema-registry failed to start because was not finding kafka broker