### PR TITLE
[hotfix] add snappy-java dependency to fix jenkins pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,11 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- The following dependencies on ScalaTest are only required for the Scala tests
              under src/test/scala/.  They are not required for Java code/tests.


### PR DESCRIPTION
Getting following error in Jenkins - https://jenkins.confluent.io/job/confluentinc/job/kafka-streams-examples/job/master/9245/console . I could re-produce it locally with `mvn test`, and it's gone after adding the `snappy-java` dependency
```
[2024-01-25 18:03:24,546] ERROR [Thread-1] Thread Thread[Thread-1,5,main] died (org.apache.zookeeper.server.NIOServerCnxnFactory)
13:03:24  java.lang.NoClassDefFoundError: org/xerial/snappy/SnappyOutputStream
13:03:24  	at org.apache.zookeeper.server.persistence.Util.makeSnapshotName(Util.java:97)
13:03:24  	at org.apache.zookeeper.server.persistence.FileTxnSnapLog.save(FileTxnSnapLog.java:478)
13:03:24  	at org.apache.zookeeper.server.persistence.FileTxnSnapLog.restore(FileTxnSnapLog.java:300)
13:03:24  	at org.apache.zookeeper.server.ZKDatabase.loadDataBase(ZKDatabase.java:285)
13:03:24  	at org.apache.zookeeper.server.ZooKeeperServer.loadData(ZooKeeperServer.java:531)
13:03:24  	at org.apache.zookeeper.server.ZooKeeperServer.startdata(ZooKeeperServer.java:704)
13:03:24  	at org.apache.zookeeper.server.NIOServerCnxnFactory.startup(NIOServerCnxnFactory.java:744)
13:03:24  	at org.apache.zookeeper.server.ServerCnxnFactory.startup(ServerCnxnFactory.java:130)
13:03:24  	at org.apache.zookeeper.server.ZooKeeperServerMain.runFromConfig(ZooKeeperServerMain.java:161)
13:03:24  	at org.apache.curator.test.TestingZooKeeperMain.runFromConfig(TestingZooKeeperMain.java:73)
13:03:24  	at org.apache.curator.test.TestingZooKeeperServer$1.run(TestingZooKeeperServer.java:148)
13:03:24  	at java.lang.Thread.run(Thread.java:748)
13:03:24  Caused by: java.lang.ClassNotFoundException: org.xerial.snappy.SnappyOutputStream
13:03:24  	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
13:03:24  	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
13:03:24  	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
13:03:24  	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
13:03:24  	... 12 more
```