### PR TITLE
chore: disable semaphore

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -13,6 +13,8 @@ semaphore:
   maven_skip_deploy: true
   build_arm: true
   nano_version: true
+  branches: []
+  triggers: []
 
 # Properties not ported from Jenkinsfile:
 #


### PR DESCRIPTION
Finishing the semaphore migration is blocked, see https://confluentinc.atlassian.net/browse/KSTREAMS-5779.

Meanwhile, the semaphore job is failing and creating lots of testbreak ticket noise, so I'm trying to disable it.