### PR TITLE
MINOR: disable tag builds

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -13,4 +13,5 @@ semaphore:
   maven_skip_deploy: true
   build_arm: true
   nano_version: true
+  triggers: ['branches', 'pull_requests']
   os_types: ['ubi8']


### PR DESCRIPTION
As per comments on https://confluentinc.atlassian.net/browse/KSTREAMS-5737, we should just disable tag builds