### PR TITLE
MINOR: Fix config names

### DIFF
--- a/src/test/java/io/confluent/examples/streams/microservices/util/MicroserviceTestUtils.java
+++ b/src/test/java/io/confluent/examples/streams/microservices/util/MicroserviceTestUtils.java
@@ -53,9 +53,9 @@ public class MicroserviceTestUtils {
         {
           //Transactions need durability so the defaults require multiple nodes.
           //For testing purposes set transactions to work with a single kafka broker.
-          put(KafkaConfig.TransactionsTopicReplicationFactorProp(), "1");
-          put(KafkaConfig.TransactionsTopicMinISRProp(), "1");
-          put(KafkaConfig.TransactionsTopicPartitionsProp(), "1");
+          put("transaction.state.log.replication.factor", "1");
+          put("transaction.state.log.min.isr", "1");
+          put("transaction.state.log.num.partitions", "1");
         }
       });
 


### PR DESCRIPTION
Commit 61baa7ac6bb871797197d9289a848a0d4f587ced in Kafka moved around the internal fields for these public configs.

We should not depend on the internal fields, otherwise we will keep breaking here. Just use the public API.