### PR TITLE
KSTREAMS-5737: Enable signing

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -13,5 +13,6 @@ semaphore:
   maven_skip_deploy: true
   build_arm: true
   nano_version: true
+  sign_image: true
   triggers: ['branches', 'pull_requests']
   os_types: ['ubi8']


### PR DESCRIPTION
While migrating to semaphoreCI, we want to have our CP docker images signed in order to comply to container hardening/ FedRamp requirements. To enable image signing, we just need to include sign_image: true in service.yml and apply the changes by running service bot. Further described in wiki