### PR TITLE
KSTREAMS-5737: Fix image signing parameter

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -13,6 +13,6 @@ semaphore:
   maven_skip_deploy: true
   build_arm: true
   nano_version: true
-  sign_image: true
+  sign_images: true
   triggers: ['branches', 'pull_requests']
   os_types: ['ubi8']


### PR DESCRIPTION
Parameter name in the wiki was incorrect (there is no easy way to test these things).

in https://github.com/confluentinc/cc-service-bot/blob/master/servicebot/plugin_semaphore.py we have "sign_images"

but in the wiki

https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/3211693075/Jenkins+-+Semaphore+self+migration+guide#How-do-I-migrate-dockerfile?

we have "sign_image"