### PR TITLE
KSTREAMS-5737 Set use_packages to true

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -16,3 +16,4 @@ semaphore:
   sign_images: true
   triggers: ['branches', 'pull_requests']
   os_types: ['ubi8']
+  use_packages: true


### PR DESCRIPTION
https://semaphore.ci.confluent.io/workflows/69a1c8ee-e4c6-4267-a33c-796154645bdc?pipeline_id=269ebc08-154c-442a-9553-f4355af3ff43 7.0.x docker build run ^^ shows that deploy blocks were skipped.

Looks like, we’ll need to set use_packages as true as per template https://github.com/confluentinc/cc-service-bot/blob/master/servicebot/templates/semaphore_pipeline_cp_dockerfile.yml.jinja2#L172