### PR TITLE
Update confluent-packaging-tools ref in mvn properties

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,4 +1,4 @@
 # custmized maven that help avoid download only highest poms from version range
 # https://issues.apache.org/jira/browse/MRESOLVER-164
-distributionUrl=https://confluent-packaging-tools.s3-us-west-2.amazonaws.com/apache-maven-3.8.1.2-bin.zip
+distributionUrl=https://confluent-packaging-tools-891377121322-us-west-2.s3-us-west-2.amazonaws.com/apache-maven-3.8.1.2-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar


### PR DESCRIPTION
SemaphoreCI builds have started failing 
https://semaphore.ci.confluent.io/jobs/7cfbf367-93b5-4d4f-bf9c-c89619e2b172#L239
https://semaphore.ci.confluent.io/jobs/14b32e04-7710-417a-8564-3d801938c03e#L241 

confluent-packaging-tools bucket has been migrated to new aws account, updating the ref