### PR TITLE
MINOR: fix build broken references and params

### DIFF
--- a/src/main/scala/io/confluent/examples/streams/algebird/CMSStore.scala
+++ b/src/main/scala/io/confluent/examples/streams/algebird/CMSStore.scala
@@ -182,10 +182,6 @@ class CMSStore[T: CMSHasher](override val name: String,
 
   @volatile private var open: Boolean = false
 
-  override def init(context: ProcessorContext, root: StateStore): Unit = {
-    throw new IllegalStateException("Should not be called as we implement `init(StateStoreContext, StateStore)`");
-  }
-
   /**
     * Initializes this store, including restoring the store's state from its changelog.
     */

--- a/src/main/scala/io/confluent/examples/streams/algebird/CMSStore.scala
+++ b/src/main/scala/io/confluent/examples/streams/algebird/CMSStore.scala
@@ -17,7 +17,7 @@ package io.confluent.examples.streams.algebird
 
 import com.twitter.algebird.{CMSHasher, TopCMS, TopPctCMS}
 import org.apache.kafka.common.serialization.Serdes
-import org.apache.kafka.streams.processor.{ProcessorContext, StateStore, StateStoreContext}
+import org.apache.kafka.streams.processor.{StateStore, StateStoreContext}
 import org.apache.kafka.streams.state.StateSerdes
 
 /**

--- a/src/test/java/io/confluent/examples/streams/ApplicationResetIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/ApplicationResetIntegrationTest.java
@@ -137,7 +137,7 @@ public class ApplicationResetIntegrationTest {
     final int exitCode = new StreamsResetter().execute(
       new String[]{
         "--application-id", applicationId,
-        "--bootstrap-servers", CLUSTER.bootstrapServers(),
+        "--bootstrap-server", CLUSTER.bootstrapServers(),
         "--input-topics", inputTopic
       });
     Assert.assertEquals(0, exitCode);


### PR DESCRIPTION
Fixing build. 

1 - Remove unsupported method that was overriding one that was recently removed with upstream change https://github.com/apache/kafka/pull/16906/files#diff-7fe11ab5459b6c6e35ee9699639025e1ce8814b8b603596f69f6e45a011e1675

2 - fix wrong param that was causing abrupt failure in ApplicationResetIntegrationTest (test crashed). Mixed in the logs there was:

      bootstrap-servers is not a recognized option
      Option (* = required) Description
      --bootstrap-server <String: server to The server(s) to connect to....

All test pass locally after these fixes.