### PR TITLE
MINOR: restore pre CP-8.0 code

### DIFF
--- a/src/main/scala/io/confluent/examples/streams/algebird/CMSStore.scala
+++ b/src/main/scala/io/confluent/examples/streams/algebird/CMSStore.scala
@@ -17,7 +17,7 @@ package io.confluent.examples.streams.algebird
 
 import com.twitter.algebird.{CMSHasher, TopCMS, TopPctCMS}
 import org.apache.kafka.common.serialization.Serdes
-import org.apache.kafka.streams.processor.{StateStore, StateStoreContext}
+import org.apache.kafka.streams.processor.{ProcessorContext, StateStore, StateStoreContext}
 import org.apache.kafka.streams.state.StateSerdes
 
 /**
@@ -181,6 +181,10 @@ class CMSStore[T: CMSHasher](override val name: String,
   private[algebird] def cmsFrom(item: T): TopCMS[T] = cmsMonoid.create(item)
 
   @volatile private var open: Boolean = false
+
+  override def init(context: ProcessorContext, root: StateStore): Unit = {
+    throw new IllegalStateException("Should not be called as we implement `init(StateStoreContext, StateStore)`");
+  }
 
   /**
     * Initializes this store, including restoring the store's state from its changelog.

--- a/src/test/java/io/confluent/examples/streams/ApplicationResetIntegrationTest.java
+++ b/src/test/java/io/confluent/examples/streams/ApplicationResetIntegrationTest.java
@@ -137,7 +137,7 @@ public class ApplicationResetIntegrationTest {
     final int exitCode = new StreamsResetter().execute(
       new String[]{
         "--application-id", applicationId,
-        "--bootstrap-server", CLUSTER.bootstrapServers(),
+        "--bootstrap-servers", CLUSTER.bootstrapServers(),
         "--input-topics", inputTopic
       });
     Assert.assertEquals(0, exitCode);


### PR DESCRIPTION
Reverts https://github.com/confluentinc/kafka-streams-examples/pull/523 which only applies to CP 8.0 release.