### PR TITLE
Update Ubuntu version from 20.04 to 24.04 - FedRAMP branch

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -7,7 +7,7 @@ version: v1.0
 name: build-test-release
 agent:
   machine:
-    type: s1-prod-ubuntu20-04-amd64-1
+    type: s1-prod-ubuntu24-04-amd64-1
 
 fail_fast:
   cancel:
@@ -160,7 +160,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu20-04-arm64-1
+          type: s1-prod-ubuntu24-04-arm64-1
       jobs:
         - name: Build & Test ubi8
           commands:
@@ -187,7 +187,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu20-04-arm64-1
+          type: s1-prod-ubuntu24-04-arm64-1
       jobs:
         - name: Deploy ARM confluentinc/kafka-streams-examples ubi8
           commands:
@@ -248,7 +248,7 @@ after_pipeline:
   task:
     agent:
       machine:
-        type: s1-prod-ubuntu20-04-arm64-0
+        type: s1-prod-ubuntu24-04-arm64-0
     jobs:
       - name: Metrics
         commands:

--- a/.semaphore/cp_dockerfile_promote.yml
+++ b/.semaphore/cp_dockerfile_promote.yml
@@ -7,7 +7,7 @@ version: v1.0
 name: build-test-release
 agent:
   machine:
-    type: s1-prod-ubuntu20-04-amd64-1
+    type: s1-prod-ubuntu24-04-amd64-1
 
 fail_fast:
   cancel:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -7,7 +7,7 @@ version: v1.0
 name: build-test-release
 agent:
   machine:
-    type: s1-prod-ubuntu20-04-amd64-1
+    type: s1-prod-ubuntu24-04-amd64-1
 
 fail_fast:
   cancel:
@@ -124,7 +124,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu20-04-arm64-1
+          type: s1-prod-ubuntu24-04-arm64-1
       jobs:
         - name: Build & Test ubi8
           commands:
@@ -148,7 +148,7 @@ after_pipeline:
   task:
     agent:
       machine:
-        type: s1-prod-ubuntu20-04-arm64-0
+        type: s1-prod-ubuntu24-04-arm64-0
     jobs:
       - name: Metrics
         commands:


### PR DESCRIPTION
This PR updates the Ubuntu version from 20.04 to 24.04 in the .semaphore directory files.