### PR TITLE
DP-16708: Switch to using confluent-devtools

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,7 +31,6 @@ global_job_config:
       - export BUILD_NUMBER=$(echo $SEMAPHORE_WORKFLOW_ID | cut -f1 -d"-")
       - export BRANCH_TAG=$(echo $SEMAPHORE_GIT_BRANCH | tr / -)
       # For PR Builds using Packaging
-      - pip install confluent-devtools
       - if [ $BRANCH_TAG == "master" ]; then export BUILD_KEY=$(pinto get-master-version); else export BUILD_KEY=$BRANCH_TAG; fi
       - export PACKAGING_BUCKET="s3://dev-confluent-packages-654654529379-us-west-2/$BRANCH_TAG/"
       - export LATEST_PACKAGING_BUILD_NUMBER=$(aws s3 ls $PACKAGING_BUCKET --no-paginate | grep 'PRE' | awk '{print $NF}' | awk '{print substr($1, 1, length($1)-1)}' | sort -n | tail -n 1)


### PR DESCRIPTION
As part of the [depot migration task](https://confluentinc.atlassian.net/browse/DP-16108), replace release-tools with confluent-devtools. Remove all the installation of release-tools. We don't need to install release-tools on CI since it is preinstalled on CI AMI images. 

One Pager: https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/4020831896/Depot+-+Python+Walled+Garden+Repository