### PR TITLE
Add Confluent Cloud promotional banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 > This repo is replaced with [Confluent Tutorials for Apache Kafka](https://github.com/confluentinc/tutorials).
 We still "keep the lights on", but we don't improve existing examples any longer, nor do we add new example.
 
+[![Try Confluent Cloud - The Data Streaming Platform](https://images.ctfassets.net/8vofjvai1hpv/10bgcSfn5MzmvS4nNqr94J/af43dd2336e3f9e0c0ca4feef4398f6f/confluent-banner-v2.svg)](https://confluent.cloud/signup?utm_source=github&utm_medium=banner&utm_campaign=oss-repos&utm_term=kafka-streams-examples)
+
 This project contains code examples that demonstrate how to implement real-time applications and event-driven
 microservices using the Streams API of [Apache Kafka](http://kafka.apache.org/) aka Kafka Streams.
 


### PR DESCRIPTION
## Summary  
- Adds promotional banner for Confluent Cloud after existing warning/notice
- Banner includes call-to-action for $400 free credits
- Uses centrally managed SVG from Contentful CMS

## Changes
- Added banner after the existing warning/note block
- Includes UTM parameters for tracking (utm_term=kafka-streams-examples)