### PR TITLE
Cherry-pick dependency fixes for 7.9.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,7 +419,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.14.0</version>
                 <inherited>true</inherited>
                 <configuration>
                     <source>${java.version}</source>

--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,12 @@
             <artifactId>curator-test</artifactId>
             <version>2.9.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>


### PR DESCRIPTION
Cherry-pick of dependency fixes for the 7.9.6 release.

- Cherry-pick of https://github.com/confluentinc/kafka-streams-examples/pull/620 - Exclude log4j 1.x from curator-test dependency
- Cherry-pick of https://github.com/confluentinc/kafka-streams-examples/pull/629 - Upgrade maven-compiler-plugin to 3.14.0