### PR TITLE
Add cp-build-and-release-team as codeowner for CI/CD files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 # assign Kafak Streams and Java Client team as reviewers for all PRs:
 *       @confluentinc/streams @confluentinc/kafka-java-client
+.semaphore/	@confluentinc/streams @confluentinc/kafka-java-client @confluentinc/cp-build-and-release-team
+service.yml	@confluentinc/streams @confluentinc/kafka-java-client @confluentinc/cp-build-and-release-team


### PR DESCRIPTION
Add @confluentinc/cp-build-and-release-team as codeowner for .semaphore/ and service.yml.