### PR TITLE
CPBR-3662: Guard ci-push-tag to skip on release builds

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -252,7 +252,14 @@ blocks:
           commands:
             - export DOCKER_PROD_IMAGE_NAME=$DOCKER_PROD_REGISTRY${DOCKER_REPOS// / $DOCKER_PROD_REGISTRY}
             - ci-tools ci-update-version --direct-pom-edit
-            - ci-tools ci-push-tag
+            # Skip ci-push-tag for release builds. Without this guard, -rc and -cp builds also push
+            # tags via this line — for -rc builds the tags are in a different format which is
+            # unexpected and unused, and for -cp builds it pushes the same tags as nightly which is
+            # also not the intended behavior.
+            - |-
+              if [[ ! $IS_RELEASE ]]; then
+                ci-tools ci-push-tag
+              fi
             - echo "Skipping Maven Deploy"
             # Create manifest
             - >-


### PR DESCRIPTION
## Summary

Roll out the `ci-push-tag` guard fix from [CPBR-3660](https://confluentinc.atlassian.net/browse/CPBR-3660) / [cc-service-bot PR #1963](https://github.com/confluentinc/cc-service-bot/pull/1963).

`ci-tools ci-push-tag` was running unconditionally in the `nano_version` block, causing unintended tag pushes on `-rc` and `-cp` builds:
- On `-rc` builds: pushes tags in an unexpected/unused format
- On `-cp` builds: pushes the same tags as nightly, which is not the intended behavior
- Example: on `8.0.2-cp6` branch, `ci-update-version` finds RC tags like `v8.0.2-9` and creates `v8.0.2-10`, polluting the tag namespace

**Fix:** Wrapped `ci-tools ci-push-tag` in `if [[ ! $IS_RELEASE ]]` guard so tags are only pushed for non-release builds.

## Test plan
- [ ] Verify nightly builds on `.x` branches still push tags as before
- [ ] Verify `-rc` and `-cp` builds no longer push unintended tags

Jira: [CPBR-3662](https://confluentinc.atlassian.net/browse/CPBR-3662)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CPBR-3660]: https://confluentinc.atlassian.net/browse/CPBR-3660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CPBR-3662]: https://confluentinc.atlassian.net/browse/CPBR-3662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ