### PR TITLE
Upgrade maven-compiler-plugin to 3.14.0 (cherry-pick from 7.8.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.14.0</version>
                 <inherited>true</inherited>
                 <configuration>
                     <source>${java.version}</source>


### PR DESCRIPTION
Cherry-picks `87e7f37e` from `7.8.x` onto `7.8.8-rc260424205322`.

**Fix:** bumps `maven-compiler-plugin` from 3.3 → 3.14.0.

**Root cause of build failure:** `maven-compiler-plugin:3.3` has a transitive dep on `log4j:1.2.12` (via `velocity-tools:2.0` → `commons-digester:1.8`). That artifact is no longer resolvable from the configured Maven mirrors (`third-party-artifacts`, `confluent-artifactory-central`, `packages.confluent.io`). The 3.14.0 plugin drops that chain.

**Precedent:** the latest RC of the previous version already carries this fix — see https://github.com/confluentinc/kafka-streams-examples/tree/7.8.7-rc260218111616 (landed there via PR #626).

This RC was cut from a stale base and missed the bump that's already on `7.8.x`.
