### PR TITLE
Run build and test blocks on master, not only on pull requests

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -117,7 +117,7 @@ blocks:
   - name: Build, Test, & Scan AMD
     dependencies: ["Validation"]
     run:
-      when: "pull_request =~ '.*'"
+      when: "pull_request =~ '.*' or branch = 'master'"
     task:
       jobs:
         - name: Build, Test, & Scan ubi9
@@ -146,7 +146,7 @@ blocks:
   - name: Build & Test ARM
     dependencies: ["Validation"]
     run:
-      when: "pull_request =~ '.*'"
+      when: "pull_request =~ '.*' or branch = 'master'"
     task:
       agent:
         machine:

--- a/service.yml
+++ b/service.yml
@@ -12,6 +12,18 @@ codeowners:
 semaphore:
   enable: true
   pipeline_type: cp-dockerfile
+  # 'blocks' is deliberately omitted so ServiceBot does not regenerate it. The build blocks in
+  # .semaphore/semaphore.yml are gated to also run on master; without this, that gating is reset
+  # on the next ServiceBot regeneration and master builds nothing again.
+  managed_sections:
+    - version
+    - name
+    - agent
+    - fail_fast
+    - execution_time_limit
+    - queue
+    - global_job_config
+    - after_pipeline
   docker_repos: ['confluentinc/kafka-streams-examples']
   community_docker_repos: []
   community_maven_modules: []


### PR DESCRIPTION
Both build blocks are gated `when: "pull_request =~ '.*'"`, so pushes to master skip every block — nothing is compiled or tested, and a green pipeline carries no signal.

Gates both build blocks on master too, and adds `managed_sections` omitting `blocks` to `service.yml` so ServiceBot preserves that gating (the `cp-dockerfile` default includes `blocks`, so otherwise it is regenerated away).

The `or` in the `when:` expression evaluates correctly for the PR case — the build blocks ran on this PR rather than being skipped. The master case can only be confirmed by the first master build after merge, and `managed_sections` only takes effect on the next ServiceBot run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)